### PR TITLE
ci: harden pipeline and fix semantic release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
-  release:
-    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,33 +15,29 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Authenticate with GitHub Packages
-        run: echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          registry-url: https://npm.pkg.github.com
+          scope: '@budget-buddy-org'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         run: pnpm lint
 
       - name: Build
         run: pnpm build
-
-      - name: Type check
-        run: pnpm type-check
 
       - name: Test
         run: pnpm test
@@ -57,174 +52,35 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Authenticate with GitHub Packages
-        run: echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          registry-url: https://npm.pkg.github.com
+          scope: '@budget-buddy-org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
         run: pnpm exec semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish:
-    needs: ci
-    runs-on: ubuntu-latest
-    # Only run on a published release (created by semantic-release) — not on PRs or direct pushes
-    if: github.event_name == 'release' && github.event.action == 'published'
-    permissions:
-      contents: read
-      packages: write
-      attestations: write    # for SBOM/provenance
-      id-token: write        # for keyless Cosign signing via OIDC
-      security-events: write # for uploading SARIF scan results
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up QEMU (multi-platform emulation)
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract image metadata
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
-        with:
-          images: ghcr.io/budget-buddy-org/budget-buddy-web-app
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
-
-      # Build a single-platform (amd64) image locally so we can scan it
-      # before pushing anything to the registry. Reuse GHA cache to avoid
-      # rebuilding layers that haven't changed since the last push.
-      - name: Build image for scanning (amd64, no push)
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
-        with:
-          context: .
-          platforms: linux/amd64
-          push: false
-          load: true
-          tags: ghcr.io/budget-buddy-org/budget-buddy-web-app:scan
-          build-args: VITE_API_URL=${{ vars.VITE_API_URL }}
-          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
-          cache-from: type=gha
-
-      # Scan CRITICAL+HIGH findings and upload to the Security tab for full
-      # visibility. Non-blocking — HIGH findings appear as warnings only.
-      - name: Scan image with Trivy (amd64, SARIF)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          image-ref: ghcr.io/budget-buddy-org/budget-buddy-web-app:scan
-          format: sarif
-          output: trivy-amd64.sarif
-          exit-code: '0'
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-
-      - name: Upload amd64 scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        if: always()
-        with:
-          sarif_file: trivy-amd64.sarif
-          category: trivy-amd64
-
-      # Blocking gate — fails the job only on unfixed CRITICAL CVEs.
-      #
-      # Deliberate policy: HIGH vulnerabilities do not block pushes.
-      # Rationale: nginx:1.29-alpine ships with 3 unfixed HIGH CVEs in base
-      # Alpine packages that have no upstream fix yet. Blocking on HIGH would
-      # permanently halt the pipeline for issues outside our control. CRITICAL
-      # CVEs represent a meaningfully higher risk bar and are always blocked.
-      # HIGH findings remain fully visible in the repo's Security tab.
-      - name: Block on CRITICAL vulnerabilities (amd64)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          image-ref: ghcr.io/budget-buddy-org/budget-buddy-web-app:scan
-          format: table
-          exit-code: '1'
-          severity: CRITICAL
-          ignore-unfixed: true
-
-      # Build the final multi-platform image and push it. SBOM and provenance
-      # attestations are attached automatically by build-push-action.
-      - name: Build and push multi-platform image
-        id: build-push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: VITE_API_URL=${{ vars.VITE_API_URL }}
-          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
-          sbom: true
-          provenance: mode=max
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # Scan the arm64 image by digest from the registry to catch arch-specific
-      # vulnerabilities in base image packages that may differ from amd64.
-      # Intentionally non-blocking (continue-on-error: true, no exit-code) —
-      # findings are surfaced in the Security tab for visibility without gating
-      # releases on arch-specific vulns that may not be fixable upstream.
-      - name: Scan image with Trivy (arm64)
-        id: trivy-arm64
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        continue-on-error: true
-        with:
-          image-ref: ghcr.io/budget-buddy-org/budget-buddy-web-app@${{ steps.build-push.outputs.digest }}
-          format: sarif
-          output: trivy-arm64.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-        env:
-          TRIVY_PLATFORM: linux/arm64
-
-      - name: Upload arm64 scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        # Guard on the scan step's own outcome rather than build-push so this
-        # remains correct if the arm64 scan is ever decoupled from build-push.
-        if: always() && steps.trivy-arm64.outcome != 'skipped'
-        with:
-          sarif_file: trivy-arm64.sarif
-          category: trivy-arm64
-
-      # Install Cosign for keyless image signing (GitHub OIDC — no long-lived key).
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      # Sign the published image digest with Cosign. Uses GitHub's OIDC token
-      # so no signing key needs to be stored or rotated.
-      - name: Sign image with Cosign (keyless)
-        run: |
-          cosign sign --yes \
-            ghcr.io/budget-buddy-org/budget-buddy-web-app@${{ steps.build-push.outputs.digest }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,149 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write    # for SBOM/provenance
+  id-token: write        # for keyless Cosign signing via OIDC
+  security-events: write # for uploading SARIF scan results
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up QEMU (multi-platform emulation)
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        with:
+          images: ghcr.io/budget-buddy-org/budget-buddy-web-app
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      # Build a single-platform (amd64) image locally so we can scan it
+      # before pushing anything to the registry. Reuse GHA cache to avoid
+      # rebuilding layers that haven't changed since the last push.
+      - name: Build image for scanning (amd64, no push)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ghcr.io/budget-buddy-org/budget-buddy-web-app:scan
+          build-args: VITE_API_URL=${{ vars.VITE_API_URL }}
+          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=gha
+
+      # Scan CRITICAL+HIGH findings and upload to the Security tab for full
+      # visibility. Non-blocking — HIGH findings appear as warnings only.
+      - name: Scan image with Trivy (amd64, SARIF)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ghcr.io/budget-buddy-org/budget-buddy-web-app:scan
+          format: sarif
+          output: trivy-amd64.sarif
+          exit-code: '0'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Upload amd64 scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        if: always()
+        with:
+          sarif_file: trivy-amd64.sarif
+          category: trivy-amd64
+
+      # Blocking gate — fails the job only on unfixed CRITICAL CVEs.
+      #
+      # Deliberate policy: HIGH vulnerabilities do not block pushes.
+      # Rationale: nginx:1.29-alpine ships with 3 unfixed HIGH CVEs in base
+      # Alpine packages that have no upstream fix yet. Blocking on HIGH would
+      # permanently halt the pipeline for issues outside our control. CRITICAL
+      # CVEs represent a meaningfully higher risk bar and are always blocked.
+      # HIGH findings remain fully visible in the repo's Security tab.
+      - name: Block on CRITICAL vulnerabilities (amd64)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ghcr.io/budget-buddy-org/budget-buddy-web-app:scan
+          format: table
+          exit-code: '1'
+          severity: CRITICAL
+          ignore-unfixed: true
+
+      # Build the final multi-platform image and push it. SBOM and provenance
+      # attestations are attached automatically by build-push-action.
+      - name: Build and push multi-platform image
+        id: build-push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: VITE_API_URL=${{ vars.VITE_API_URL }}
+          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Scan the arm64 image by digest from the registry to catch arch-specific
+      # vulnerabilities in base image packages that may differ from amd64.
+      # Intentionally non-blocking (continue-on-error: true, no exit-code) —
+      # findings are surfaced in the Security tab for visibility without gating
+      # releases on arch-specific vulns that may not be fixable upstream.
+      - name: Scan image with Trivy (arm64)
+        id: trivy-arm64
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        continue-on-error: true
+        with:
+          image-ref: ghcr.io/budget-buddy-org/budget-buddy-web-app@${{ steps.build-push.outputs.digest }}
+          format: sarif
+          output: trivy-arm64.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+        env:
+          TRIVY_PLATFORM: linux/arm64
+
+      - name: Upload arm64 scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        # Guard on the scan step's own outcome rather than build-push so this
+        # remains correct if the arm64 scan is ever decoupled from build-push.
+        if: always() && steps.trivy-arm64.outcome != 'skipped'
+        with:
+          sarif_file: trivy-arm64.sarif
+          category: trivy-arm64
+
+      # Install Cosign for keyless image signing (GitHub OIDC — no long-lived key).
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      # Sign the published image digest with Cosign. Uses GitHub's OIDC token
+      # so no signing key needs to be stored or rotated.
+      - name: Sign image with Cosign (keyless)
+        run: |
+          cosign sign --yes \
+            ghcr.io/budget-buddy-org/budget-buddy-web-app@${{ steps.build-push.outputs.digest }}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@playwright/test": "^1.59.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
+    "@semantic-release/npm": "^13.1.5",
     "@tanstack/router-plugin": "^1.167.12",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@semantic-release/git':
         specifier: ^10.0.1
         version: 10.0.1(semantic-release@25.0.3(typescript@5.9.3))
+      '@semantic-release/npm':
+        specifier: ^13.1.5
+        version: 13.1.5(semantic-release@25.0.3(typescript@5.9.3))
       '@tanstack/router-plugin':
         specifier: ^1.167.12
         version: 1.167.12(@tanstack/react-router@1.168.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))

--- a/release.config.js
+++ b/release.config.js
@@ -4,11 +4,12 @@ export default {
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     ['@semantic-release/changelog', { changelogFile: 'CHANGELOG.md' }],
+    ['@semantic-release/npm', { npmPublish: false }],
     '@semantic-release/github',
     [
       '@semantic-release/git',
       {
-        assets: ['CHANGELOG.md'],
+        assets: ['CHANGELOG.md', 'package.json'],
         message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
       },
     ],


### PR DESCRIPTION
## Why

The CI pipeline had several correctness and security gaps: installs were non-reproducible, type-checking ran twice, action versions were unpinned in jobs with write permissions, semantic-release couldn't push through branch protection, and the publish job unnecessarily re-ran the full CI suite on every release event.

## What changed

- **Reproducible installs** — `--frozen-lockfile` in the CI job; previously `--no-frozen-lockfile` allowed silent dep drift between CI and the lockfile
- **Remove redundant type-check step** — `pnpm build` already runs `tsc -b`; the separate `pnpm type-check` step was running TypeScript twice
- **Pin action SHAs in `ci` and `release` jobs** — floating major-version tags are a supply chain risk for jobs with `contents: write`; publish job was already pinned
- **GitHub Packages auth via `actions/setup-node`** — replaced inline `~/.npmrc` writes with `registry-url` + `NODE_AUTH_TOKEN`, the officially recommended pattern
- **`workflow_dispatch` trigger** — enables manual re-runs without a new commit
- **Split `publish` into its own workflow** (`publish.yml`, triggered by `release: published`) — eliminates the redundant full CI run that previously fired on every release event just to satisfy `needs: ci`
- **GitHub App token for semantic-release** — uses `RELEASE_BOT_ID` + `RELEASE_BOT_PRIVATE_KEY` to generate an installation token; checkout and semantic-release both use it so the release commit can bypass branch protection on `main`
- **`package.json` version sync** — added `@semantic-release/npm` (`npmPublish: false`) so the version in `package.json` tracks the GitHub release tag; `package.json` added to `@semantic-release/git` assets

## How to verify

- Merge to `main` with a `feat:` commit message and confirm:
  - CI job passes with frozen lockfile
  - Release job creates a GitHub release and bumps `package.json` version in a `chore(release):` commit
  - Publish workflow triggers from the release event and pushes the Docker image to GHCR with correct semver tags
- Confirm the `chore(release):` commit is authored by the GitHub App, not the default `github-actions` bot
- Manually trigger the workflow from the Actions tab to confirm `workflow_dispatch` works