### PR TITLE
Fix API client base URL not applied to requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@budget-buddy-org/budget-buddy-contracts": "^2.0.0",
+    "@budget-buddy-org/budget-buddy-contracts": "^2.1.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@budget-buddy-org/budget-buddy-contracts':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -349,8 +349,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@budget-buddy-org/budget-buddy-contracts@2.0.0':
-    resolution: {integrity: sha512-30XR7xlzHfKXSwlzXpNhkGLy3CneHFVqyQ+sg9kIWO+6/1SBQfegi/TTp1ScJwyXURL/c0hsj7qPkzFSnSvEog==, tarball: https://npm.pkg.github.com/download/@budget-buddy-org/budget-buddy-contracts/2.0.0/30abedcdb35db2eccce7897a877c8f691cf4c3eb}
+  '@budget-buddy-org/budget-buddy-contracts@2.1.0':
+    resolution: {integrity: sha512-bmEceeq47WOKFZNNUtUJJfwgbhSJbJwo+rMNdZZbhCohgllDFYSgXR8fwm0sSVRVNRGbiFKJZdsB1bO+m1CAHQ==, tarball: https://npm.pkg.github.com/download/@budget-buddy-org/budget-buddy-contracts/2.1.0/4ce9461ea8bcb50b44fa3b01e948453140b84dc1}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -4343,7 +4343,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@budget-buddy-org/budget-buddy-contracts@2.0.0': {}
+  '@budget-buddy-org/budget-buddy-contracts@2.1.0': {}
 
   '@colors/colors@1.5.0':
     optional: true

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,4 @@
 import { refreshToken as refreshAction } from '@budget-buddy-org/budget-buddy-contracts'
-// @ts-ignore - The package might not export these from root, but we need them for configuration
 import { client } from '@budget-buddy-org/budget-buddy-contracts/client.gen'
 import { useAuthStore } from '@/stores/auth.store'
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { routeTree } from './routeTree.gen'
 import { queryClient } from './lib/query-client'
+import './lib/api'
 import './index.css'
 
 const router = createRouter({ routeTree })


### PR DESCRIPTION
## Why

All API requests were being sent to `localhost:5173` (the Vite dev server) instead of the configured API URL. `api.ts` sets the client base URL as a module side effect, but it was never imported anywhere, so the configuration never ran.

## What changed

- **`src/main.tsx`** — adds `import './lib/api'` so the client is configured at app startup, before any route renders or query fires
- **`src/lib/api.ts`** — removes the `@ts-ignore` comment on the `./client.gen` import, which is no longer needed
- **`package.json` / `pnpm-lock.yaml`** — upgrades `@budget-buddy-org/budget-buddy-contracts` from v2.0.0 to v2.1.0, which adds `"./client.gen"` to the package `exports` field so Vite can resolve the import without aliases or workarounds

## How to verify

1. Set `VITE_API_URL=http://localhost:8080` in `.env.local`
2. Run `pnpm dev`
3. Open the login page and submit credentials
4. In the browser Network tab, confirm the login request goes to `http://localhost:8080/v1/auth/login` (not `localhost:5173`)

## Notes

The root cause in the contracts package (`./client.gen` missing from exports) was fixed in v2.1.0 of `@budget-buddy-org/budget-buddy-contracts`. Previous workarounds (a Vite resolve alias) were considered and rejected in favour of fixing the package.