### PR TITLE
feat(ci): align workflows, release config, and commit conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,15 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
 
-  # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://npm.pkg.github.com
           scope: '@budget-buddy-org'
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.RELEASE_BOT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://npm.pkg.github.com
           scope: '@budget-buddy-org'

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,37 @@
+name: Commitlint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint commit messages
+        if: github.actor != 'dependabot[bot]'
+        run: pnpm exec commitlint --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
+
+      - name: Lint PR title
+        if: github.actor != 'dependabot[bot]'
+        run: echo "${{ github.event.pull_request.title }}" | pnpm exec commitlint --verbose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,9 @@ Required format: `type(scope): subject` — scope is optional.
 |---|---|---|
 | `feat` | new user-facing feature | minor |
 | `fix` | bug fix | patch |
+| `perf` | performance improvement | patch |
+| `revert` | reverts a previous commit | patch |
 | `feat!` / `BREAKING CHANGE:` footer | breaking API change | major |
-| `chore`, `docs`, `test`, `refactor`, `style`, `perf`, `build`, `ci` | everything else | none |
+| `chore`, `docs`, `test`, `refactor`, `style`, `build`, `ci`, `ops` | everything else | none |
 
 **Releases are fully automated.** Merging to `main` triggers semantic-release in CI, which analyzes commits since the last release, bumps the version, writes `CHANGELOG.md`, and publishes a GitHub release. That release event then triggers the Docker image build and push to GHCR with proper semver tags.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,10 @@
-export default { extends: ['@commitlint/config-conventional'] };
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [2, 'always', [
+      'feat', 'fix', 'docs', 'style', 'refactor',
+      'perf', 'test', 'build', 'ci', 'chore', 'revert', 'ops',
+    ]],
+    'subject-case': [0],
+  },
+};

--- a/release.config.js
+++ b/release.config.js
@@ -1,8 +1,25 @@
 export default {
   branches: ['main'],
   plugins: [
-    '@semantic-release/commit-analyzer',
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/commit-analyzer', {
+      preset: 'conventionalcommits',
+      releaseRules: [
+        { breaking: true, release: 'major' },
+        { type: 'feat', release: 'minor' },
+        { type: 'fix', release: 'patch' },
+        { type: 'perf', release: 'patch' },
+        { type: 'revert', release: 'patch' },
+        { type: 'docs', release: false },
+        { type: 'style', release: false },
+        { type: 'chore', release: false },
+        { type: 'refactor', release: false },
+        { type: 'test', release: false },
+        { type: 'build', release: false },
+        { type: 'ci', release: false },
+        { type: 'ops', release: false },
+      ],
+    }],
+    ['@semantic-release/release-notes-generator', { preset: 'conventionalcommits' }],
     ['@semantic-release/changelog', { changelogFile: 'CHANGELOG.md' }],
     ['@semantic-release/npm', { npmPublish: false }],
     '@semantic-release/github',


### PR DESCRIPTION
- ci.yml: upgrade node-version to 24; update create-github-app-token to v3.1.1
- commitlint.yml: add CI workflow to enforce commitlint on PRs (was only enforced locally via husky — now also enforced in CI)
- commitlint.config.js: add ops type; disable subject-case rule
- release.config.js: add conventionalcommits preset to commit-analyzer and release-notes-generator; add explicit releaseRules aligned with other repos
- dependabot.yml: add chore commit-message prefix to prevent dependabot PRs from triggering semantic-release
- CLAUDE.md: add revert (patch) and ops (none) to commit type table