### PR TITLE
fix: reset isRefreshing when no refresh token is present on 401

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -159,6 +159,45 @@ describe('API response interceptor', () => {
     expect(hrefSetter).toHaveBeenCalledWith('/login')
   })
 
+  it('queues concurrent 401s and replays them once the refresh resolves', async () => {
+    // Hold the refresh response until we choose to release it
+    let resolveRefresh!: (v: any) => void
+    vi.mocked(refreshToken).mockReturnValue(
+      new Promise((res) => { resolveRefresh = res }) as any,
+    )
+    mockClientRequest.mockResolvedValue({ response: makeResponse(200) })
+
+    // Fire first 401 — sets isRefreshing=true, then suspends at await refreshAction(...)
+    const first = responseInterceptor!(makeResponse(401), makeRequest(), { headers: new Headers() })
+
+    // Fire second 401 while refresh is still in-flight — must be queued, not start a new refresh
+    const second = responseInterceptor!(makeResponse(401), makeRequest(), { headers: new Headers() })
+
+    // Now let the refresh complete
+    resolveRefresh({ data: { access_token: 'at-new', refresh_token: 'rt-new' } })
+
+    await Promise.all([first, second])
+
+    // Refresh called exactly once; both original requests retried
+    expect(refreshToken).toHaveBeenCalledOnce()
+    expect(mockClientRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats a refresh response with no data as a failure and clears auth', async () => {
+    vi.mocked(refreshToken).mockResolvedValue({ data: undefined } as any)
+
+    const hrefSetter = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, set href(v: string) { hrefSetter(v) } },
+    })
+
+    await responseInterceptor!(makeResponse(401), makeRequest(), {})
+
+    expect(mockAuthState.clearAuth).toHaveBeenCalled()
+    expect(hrefSetter).toHaveBeenCalledWith('/login')
+  })
+
   it('does not leave isRefreshing=true after the no-refresh-token path (regression)', async () => {
     // First 401 with no refresh token — previously left isRefreshing=true
     mockAuthState.refreshToken = null

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -143,8 +143,6 @@ describe('API response interceptor', () => {
     expect(hrefSetter).toHaveBeenCalledWith('/login')
   })
 
-  // This test MUST run last in this describe block: the early return in api.ts (no refresh
-  // token path) sets isRefreshing=true without resetting it, which would stall subsequent tests.
   it('clears auth and redirects to /login when there is no refresh token', async () => {
     mockAuthState.refreshToken = null
 
@@ -159,5 +157,26 @@ describe('API response interceptor', () => {
 
     expect(mockAuthState.clearAuth).toHaveBeenCalled()
     expect(hrefSetter).toHaveBeenCalledWith('/login')
+  })
+
+  it('does not leave isRefreshing=true after the no-refresh-token path (regression)', async () => {
+    // First 401 with no refresh token — previously left isRefreshing=true
+    mockAuthState.refreshToken = null
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, set href(_v: string) {} },
+    })
+    await responseInterceptor!(makeResponse(401), makeRequest(), {})
+
+    // Second 401 — now has a refresh token; must attempt refresh, not hang
+    mockAuthState.refreshToken = 'rt-valid'
+    vi.mocked(refreshToken).mockResolvedValue({
+      data: { access_token: 'at-new', refresh_token: 'rt-new' },
+    } as any)
+    mockClientRequest.mockResolvedValue({ response: makeResponse(200) })
+
+    await responseInterceptor!(makeResponse(401), makeRequest(), { headers: new Headers() })
+
+    expect(refreshToken).toHaveBeenCalledOnce()
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -42,9 +42,6 @@ client.interceptors.response.use(async (response: Response, _request: Request, o
     })
   }
 
-  options._retry = true
-  isRefreshing = true
-
   const refreshTokenValue = useAuthStore.getState().refreshToken
   if (!refreshTokenValue) {
     useAuthStore.getState().clearAuth()
@@ -53,6 +50,9 @@ client.interceptors.response.use(async (response: Response, _request: Request, o
     }
     return response
   }
+
+  options._retry = true
+  isRefreshing = true
 
   try {
     const { data } = await refreshAction({


### PR DESCRIPTION
## Why

Closes #46.

When a 401 response arrived and no refresh token was stored, the interceptor set `isRefreshing = true` then returned early — bypassing the `finally` block that resets it. Any subsequent 401 in the same page lifetime would be queued and never resolved, silently hanging all pending requests.

## What changed

- `src/lib/api.ts` — moved `options._retry = true` and `isRefreshing = true` to after the refresh-token null-check, so the flag is only set when a refresh will actually be attempted and the `finally` block always runs to reset it
- `src/lib/api.test.ts` — removed the "MUST run last" workaround comment; added a regression test that fires two consecutive 401s (first with no token, then with one) to confirm the second request is not stalled

## Acceptance criteria

- ✅ `isRefreshing` is not set to `true` on the no-refresh-token early-return path
- ✅ A subsequent 401 after the no-token path correctly attempts a refresh rather than hanging
- ✅ All existing interceptor tests still pass (58 total)

## How to verify

```bash
pnpm test        # 58 tests, all pass — including new regression test
pnpm type-check  # no errors
```