### PR TITLE
fix: ignore test files in TanStack Router route scanning

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     TanStackRouterVite({
       routesDirectory: './src/routes',
       generatedRouteTree: './src/routeTree.gen.ts',
+      routeFileIgnorePattern: '\\.test\\.tsx?$',
     }),
     react(),
     tailwindcss(),


### PR DESCRIPTION
This PR fixes the TanStack Router warning where test files in the `src/routes` directory were being incorrectly identified as route files. I've updated the `routeFileIgnorePattern` in `vite.config.ts` to ignore `.test.ts` and `.test.tsx` files.