### PR TITLE
feat: add accessibility testing (a11y) to test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,15 @@
 - Generic Message: All default error fallbacks must show a generic "Something went wrong" message and "An unexpected error occurred. Please try again later."
 - Error Details: Provide a "Show details" toggle that reveals `error.message` and `error.stack` (if available) for troubleshooting.
 - Consistency: Use consistent UI patterns for error boundaries and route-level error components.
+
+### Accessibility (a11y) Conventions
+
+#### Testing
+- Tooling: Use `vitest-axe` and `@axe-core/react` for automated accessibility testing.
+- Test Files: Create `.a11y.test.tsx` files for critical routes (e.g., login, dashboard, transactions).
+- Execution: Run a11y tests using `pnpm test:a11y`.
+
+#### Implementation
+- Headings: Ensure heading levels are progressive (e.g., `h1` must be followed by `h2`, not `h3`).
+- Interactive Elements: All icon-only buttons must include a descriptive `aria-label`.
+- Semantics: Use semantic HTML elements wherever possible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ pnpm vitest run src/hooks/useTransactions.test.ts
 Coverage report:
 ```bash
 pnpm test:coverage   # HTML report in coverage/
+pnpm test:a11y       # Run accessibility tests
 ```
 
 ## Architecture
@@ -81,6 +82,14 @@ shadcn/ui pattern: Radix UI primitives + Tailwind v4. Shared primitives live in 
 ### Data Conventions
 
 Currency amounts are stored and sent as **minor units** (integers). `1299` = €12.99. Use `src/lib/formatters.ts` for display formatting.
+
+### Accessibility Testing
+
+We use `vitest-axe` for automated accessibility checks.
+- Add `.a11y.test.tsx` for critical routes and complex components.
+- Run a11y tests specifically with `pnpm test:a11y`.
+- Ensure all icon-only buttons have an `aria-label`.
+- Maintain progressive heading levels (h1 -> h2 -> h3).
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ pnpm lint         # Biome lint
 pnpm format       # Biome auto-format
 pnpm test         # Vitest (run once)
 pnpm test:watch   # Vitest (watch mode)
+pnpm test:a11y    # Run accessibility tests
 pnpm type-check   # tsc --noEmit
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:a11y": "vitest run a11y",
     "type-check": "tsc --noEmit -p tsconfig.app.json",
     "prepare": "husky"
   },
@@ -39,6 +40,7 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@axe-core/react": "^4.11.1",
     "@biomejs/biome": "^2.4.11",
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
@@ -70,6 +72,7 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.58.1",
     "vite": "8.0.5",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
+      '@axe-core/react':
+        specifier: ^4.11.1
+        version: 4.11.1
       '@biomejs/biome':
         specifier: ^2.4.11
         version: 2.4.11
@@ -168,6 +171,9 @@ importers:
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.4)
 
 packages:
 
@@ -196,6 +202,9 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/react@4.11.1':
+    resolution: {integrity: sha512-tjTsYVQw0YhmVDpayb/r55Xbda/Og3l6UCvBZ26C+MtmuSTyQ47PKzq8z3QMgKCJ0RB7lsdiDy4HwO2SKiNuHg==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1916,6 +1925,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  axe-core@4.11.2:
+    resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
+    engines: {node: '>=4'}
+
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
@@ -3524,6 +3537,9 @@ packages:
     resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
     engines: {node: '>=14'}
 
+  requestidlecallback@0.3.0:
+    resolution: {integrity: sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -3984,6 +4000,11 @@ packages:
       yaml:
         optional: true
 
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
+
   vitest@4.1.4:
     resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -4187,6 +4208,11 @@ snapshots:
       is-potential-custom-element-name: 1.0.1
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@axe-core/react@4.11.1':
+    dependencies:
+      axe-core: 4.11.2
+      requestidlecallback: 0.3.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5879,6 +5905,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  axe-core@4.11.2: {}
+
   axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
@@ -7357,6 +7385,8 @@ snapshots:
     dependencies:
       '@pnpm/npm-conf': 3.0.2
 
+  requestidlecallback@0.3.0: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -7777,6 +7807,16 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  vitest-axe@0.1.0(vitest@4.1.4):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.11.2
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   vitest@4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -19,11 +19,12 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 )
 CardHeader.displayName = 'CardHeader'
 
-const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
-  ),
-)
+const CardTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement> & { as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' }
+>(({ className, as: Component = 'h3', ...props }, ref) => (
+  <Component ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+))
 CardTitle.displayName = 'CardTitle'
 
 const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(

--- a/src/routes/_app/index.a11y.test.tsx
+++ b/src/routes/_app/index.a11y.test.tsx
@@ -1,0 +1,75 @@
+import { render } from '@testing-library/react'
+import 'vitest-axe/extend-expect'
+import { axe } from 'vitest-axe'
+import { describe, expect, it, vi } from 'vitest'
+import { Route } from './index.lazy'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type React from 'react'
+
+vi.mock('@tanstack/react-router', () => ({
+  createLazyFileRoute: () => (options: any) => ({ options }),
+  useNavigate: () => vi.fn(),
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}))
+
+// Mock recharts to avoid rendering issues in JSDOM
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div style={{ width: '100%', height: '100%' }}>{children}</div>,
+  BarChart: ({ children }: any) => <div>{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Cell: () => null,
+}))
+
+vi.mock('@/hooks/useTransactions', () => ({
+  useTransactions: () => ({
+    data: {
+      items: [
+        {
+          id: '1',
+          description: 'Test income',
+          amount: 10000,
+          type: 'INCOME',
+          currency: 'EUR',
+          date: '2024-03-20',
+          categoryId: '1',
+        },
+        {
+          id: '2',
+          description: 'Test expense',
+          amount: 5000,
+          type: 'EXPENSE',
+          currency: 'EUR',
+          date: '2024-03-21',
+          categoryId: '2',
+        },
+      ],
+    },
+    isLoading: false,
+  }),
+}))
+
+describe('DashboardPage a11y', () => {
+  it('should have no accessibility violations', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+    
+    const DashboardPage = (Route as any).options.component as React.ElementType
+    
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <DashboardPage />
+      </QueryClientProvider>
+    )
+    
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/src/routes/_app/index.lazy.tsx
+++ b/src/routes/_app/index.lazy.tsx
@@ -89,7 +89,7 @@ function DashboardPage() {
       {chartData.length > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-sm font-medium">Monthly overview</CardTitle>
+            <CardTitle className="text-sm font-medium" as="h2">Monthly overview</CardTitle>
           </CardHeader>
           <CardContent className="pl-2">
             <ResponsiveContainer width="100%" height={180}>
@@ -111,7 +111,7 @@ function DashboardPage() {
       {/* Recent transactions */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-sm font-medium">Recent transactions</CardTitle>
+          <CardTitle className="text-sm font-medium" as="h2">Recent transactions</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
           {recent.length === 0 ? (

--- a/src/routes/_app/transactions/index.a11y.test.tsx
+++ b/src/routes/_app/transactions/index.a11y.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react'
+import 'vitest-axe/extend-expect'
+import { axe } from 'vitest-axe'
+import { describe, expect, it, vi } from 'vitest'
+import { Route } from './index.lazy'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type React from 'react'
+
+vi.mock('@tanstack/react-router', () => ({
+  createLazyFileRoute: () => (options: any) => ({ options }),
+  useNavigate: () => vi.fn(),
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}))
+
+vi.mock('@/hooks/useCategories', () => ({
+  useCategories: () => ({
+    data: {
+      items: [
+        { id: '1', name: 'Food', type: 'EXPENSE', icon: 'utensils' },
+        { id: '2', name: 'Salary', type: 'INCOME', icon: 'banknote' },
+      ],
+    },
+    isLoading: false,
+  }),
+}))
+
+vi.mock('@/hooks/useTransactions', () => ({
+  useTransactions: () => ({
+    data: {
+      items: [
+        {
+          id: '1',
+          description: 'Grocery store',
+          amount: 1250,
+          type: 'EXPENSE',
+          currency: 'EUR',
+          date: '2024-03-20',
+          categoryId: '1',
+        },
+      ],
+    },
+    isLoading: false,
+    isFetching: false,
+  }),
+  useCreateTransaction: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteTransaction: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateTransaction: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+describe('TransactionsPage a11y', () => {
+  it('should have no accessibility violations', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+    
+    const TransactionsPage = (Route as any).options.component as React.ElementType
+    
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <TransactionsPage />
+      </QueryClientProvider>
+    )
+    
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/src/routes/_app/transactions/index.lazy.tsx
+++ b/src/routes/_app/transactions/index.lazy.tsx
@@ -116,6 +116,7 @@ function TransactionsPage() {
             size="sm"
             variant={showFilters ? 'secondary' : 'outline'}
             onClick={() => setShowFilters((v) => !v)}
+            aria-label="Toggle filters"
           >
             <Filter className="h-4 w-4" />
             {hasActiveFilters && <span className="ml-1 h-1.5 w-1.5 rounded-full bg-primary" />}
@@ -337,6 +338,7 @@ function TransactionsPage() {
                       className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
                       onClick={() => deleteTx.mutate(t.id)}
                       disabled={deleteTx.isPending}
+                      aria-label="Delete transaction"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </Button>

--- a/src/routes/_auth/login.a11y.test.tsx
+++ b/src/routes/_auth/login.a11y.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react'
+import 'vitest-axe/extend-expect'
+import { axe } from 'vitest-axe'
+import { describe, expect, it, vi } from 'vitest'
+import { Route } from './login.lazy'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type React from 'react'
+
+vi.mock('@tanstack/react-router', () => ({
+  createLazyFileRoute: () => (options: any) => ({ options }),
+  useNavigate: () => vi.fn(),
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}))
+
+describe('LoginPage a11y', () => {
+  it('should have no accessibility violations', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+    
+    const LoginPage = (Route as any).options.component as React.ElementType
+    
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <LoginPage />
+      </QueryClientProvider>
+    )
+    
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,14 @@
 import '@testing-library/jest-dom'
+import 'vitest-axe/extend-expect'
+import * as axeMatchers from 'vitest-axe/matchers'
+import { expect } from 'vitest'
+
+expect.extend(axeMatchers)
+
+declare module 'vitest' {
+  export interface Assertion<T = any> extends axeMatchers.AxeMatchers {}
+  export interface AsymmetricMatchersContaining extends axeMatchers.AxeMatchers {}
+}
 
 // Provide localStorage for Zustand persist middleware in jsdom
 const localStorageMock = (() => {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest-axe/extend-expect"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
## Why

Address issue #10: Introduce automated accessibility testing to the project's test suite to ensure the web application is usable by everyone.

## What changed

- **Dependencies:** Added `vitest-axe` and `@axe-core/react`.
- **Testing Script:** Added `test:a11y` to `package.json`.
- **Global Setup:** Configured `vitest-axe` matchers and Vitest type augmentation in `src/test/setup.ts`.
- **New Tests:** Created `.a11y.test.tsx` files for login, dashboard, and transactions routes.
- **Fixes:**
  - `src/components/ui/card.tsx`: Updated `CardTitle` to support the `as` prop for semantic headings.
  - `src/routes/_app/index.lazy.tsx`: Fixed heading order (h1 -> h2).
  - `src/routes/_app/transactions/index.lazy.tsx`: Added `aria-label` to icon-only buttons.
- **Documentation:** Updated `CLAUDE.md`, `README.md`, and `AGENTS.md` with new a11y testing conventions and commands.

## Acceptance criteria

- `vitest-axe` and `@axe-core/react` are installed ✅
- `test:a11y` script exists in `package.json` ✅
- A11y tests for Login, Dashboard, and Transactions routes are implemented and passing ✅
- Project documentation is updated with a11y testing conventions ✅

## How to verify

1. Run `pnpm install` to get new dependencies.
2. Run `pnpm test:a11y` to execute only the accessibility tests.
3. Run `pnpm test` to see all tests passing.
4. Run `pnpm type-check` to verify no regression in TS types.

## Notes

None.

Closes #10