### PR TITLE
feat(ui): display field-level validation errors and improve accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@budget-buddy-org/budget-buddy-contracts": "^2.1.2",
+    "@budget-buddy-org/budget-buddy-contracts": "^2.2.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@budget-buddy-org/budget-buddy-contracts':
-        specifier: ^2.1.2
-        version: 2.1.2
+        specifier: ^2.2.0
+        version: 2.2.0
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -358,8 +358,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@budget-buddy-org/budget-buddy-contracts@2.1.2':
-    resolution: {integrity: sha512-ipdaK8RJ17Ap45Hwso9zroNVptacvVwVd+moT1sI0hqvomhD8GfTtw54HsSEb9Hd+xphThoCbgsIF9bmjvz/GQ==, tarball: https://npm.pkg.github.com/download/@budget-buddy-org/budget-buddy-contracts/2.1.2/69ded672e7408a252aed01491136675fee4bff87}
+  '@budget-buddy-org/budget-buddy-contracts@2.2.0':
+    resolution: {integrity: sha512-u2jqUV2wgehN71zKX/IOSev/DWNOOv7P9eLJmE8z02W65wqgoll2Z4FjQ7AHIWWxsL39L8qFGAHIYUcEhF3h+Q==, tarball: https://npm.pkg.github.com/download/@budget-buddy-org/budget-buddy-contracts/2.2.0/c70bba95d9ba82a11f8e5bed89eaddc03af91326}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -4369,7 +4369,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@budget-buddy-org/budget-buddy-contracts@2.1.2': {}
+  '@budget-buddy-org/budget-buddy-contracts@2.2.0': {}
 
   '@colors/colors@1.5.0':
     optional: true

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,10 +29,17 @@ export function Header() {
           size="icon"
           onClick={() => setTheme(NEXT_THEME[theme])}
           title={`Switch theme (current: ${theme})`}
+          aria-label={`Switch theme (current: ${theme})`}
         >
           <ThemeIcon className="h-4 w-4" />
         </Button>
-        <Button variant="ghost" size="icon" onClick={() => logout.mutate()} title="Log out">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => logout.mutate()}
+          title="Log out"
+          aria-label="Log out"
+        >
           <LogOut className="h-4 w-4" />
         </Button>
       </div>

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -47,9 +47,10 @@ export function useCreateCategory() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (body: CategoryWrite) => {
-      const { data } = await createCategory({
+      const { data, error } = await createCategory({
         body,
       })
+      if (error) throw error
       return data
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: KEYS.all }),
@@ -60,10 +61,11 @@ export function useUpdateCategory(id: string) {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (body: CategoryUpdate) => {
-      const { data } = await updateCategory({
+      const { data, error } = await updateCategory({
         path: { categoryId: id },
         body,
       })
+      if (error) throw error
       return data
     },
     onSuccess: () => {

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -60,9 +60,10 @@ export function useCreateTransaction() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (body: TransactionWrite) => {
-      const { data } = await createTransaction({
+      const { data, error } = await createTransaction({
         body,
       })
+      if (error) throw error
       return data
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: KEYS.all }),
@@ -73,10 +74,11 @@ export function useUpdateTransaction(id: string) {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (body: TransactionUpdate) => {
-      const { data } = await updateTransaction({
+      const { data, error } = await updateTransaction({
         path: { transactionId: id },
         body,
       })
+      if (error) throw error
       return data
     },
     onSuccess: () => {

--- a/src/routes/_app/categories/index.lazy.tsx
+++ b/src/routes/_app/categories/index.lazy.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useCategories, useCreateCategory, useDeleteCategory, useUpdateCategory } from '@/hooks/useCategories'
+import { cn } from '@/lib/cn'
 
 export const Route = createLazyFileRoute('/_app/categories/')({
   component: CategoriesPage,
@@ -19,6 +20,8 @@ function CategoriesPage() {
   const [newName, setNewName] = useState('')
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editName, setEditName] = useState('')
+
+  const createFieldError = (createCategory.error as any)?.errors?.[0]?.message
 
   const handleCreate = (e: React.FormEvent) => {
     e.preventDefault()
@@ -35,17 +38,23 @@ function CategoriesPage() {
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">Categories</h1>
 
-      <form onSubmit={handleCreate} className="flex gap-2">
-        <Input
-          placeholder="New category name…"
-          value={newName}
-          onChange={(e) => setNewName(e.target.value)}
-          maxLength={255}
-        />
-        <Button type="submit" size="sm" disabled={createCategory.isPending || !newName.trim()}>
-          <Plus className="h-4 w-4" />
-          Add
-        </Button>
+      <form onSubmit={handleCreate} className="flex flex-col gap-2">
+        <div className="flex gap-2">
+          <Input
+            placeholder="New category name…"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            maxLength={255}
+            className={createFieldError ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
+          />
+          <Button type="submit" size="sm" disabled={createCategory.isPending || !newName.trim()}>
+            <Plus className="h-4 w-4" />
+            Add
+          </Button>
+        </div>
+        {createFieldError && (
+          <p className="text-sm font-medium text-destructive">{createFieldError}</p>
+        )}
       </form>
 
       <Card>
@@ -108,6 +117,7 @@ function CategoryRow({
 }) {
   const updateCategory = useUpdateCategory(id)
   const isEditing = editingId === id
+  const updateFieldError = (updateCategory.error as any)?.errors?.[0]?.message
 
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault()
@@ -120,12 +130,12 @@ function CategoryRow({
 
   if (isEditing) {
     return (
-      <li className="flex items-center gap-2 px-4 py-2">
+      <li className="flex flex-col gap-1 px-4 py-2">
         <form onSubmit={handleSave} className="flex flex-1 items-center gap-2">
           <Input
             value={editName}
             onChange={(e) => onEditName(e.target.value)}
-            className="h-8"
+            className={cn('h-8', updateFieldError ? 'border-destructive ring-destructive focus-visible:ring-destructive' : '')}
             autoFocus
             maxLength={255}
           />
@@ -136,6 +146,9 @@ function CategoryRow({
             Cancel
           </Button>
         </form>
+        {updateFieldError && (
+          <p className="text-sm font-medium text-destructive">{updateFieldError}</p>
+        )}
       </li>
     )
   }
@@ -155,6 +168,7 @@ function CategoryRow({
         className="h-8 w-8 text-muted-foreground hover:text-destructive"
         onClick={onDelete}
         disabled={isDeleting}
+        aria-label="Delete category"
       >
         <Trash2 className="h-3.5 w-3.5" />
       </Button>

--- a/src/routes/_app/transactions/index.lazy.tsx
+++ b/src/routes/_app/transactions/index.lazy.tsx
@@ -47,6 +47,8 @@ function TransactionsPage() {
     categoryId: '',
   })
   const createTx = useCreateTransaction()
+  const createFieldErrors = (createTx.error as any)?.errors as Array<{ field: string; message: string }> | undefined
+  const getCreateFieldError = (field: string) => createFieldErrors?.find((e) => e.field === field)?.message
 
   // Edit state
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -201,7 +203,11 @@ function TransactionsPage() {
                     placeholder="Coffee, salary…"
                     value={form.description}
                     onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+                    className={getCreateFieldError('description') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
                   />
+                  {getCreateFieldError('description') && (
+                    <p className="text-[10px] font-medium text-destructive">{getCreateFieldError('description')}</p>
+                  )}
                 </div>
 
                 <div className="space-y-1">
@@ -214,7 +220,11 @@ function TransactionsPage() {
                     value={form.amount}
                     onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))}
                     required
+                    className={getCreateFieldError('amount') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
                   />
+                  {getCreateFieldError('amount') && (
+                    <p className="text-[10px] font-medium text-destructive">{getCreateFieldError('amount')}</p>
+                  )}
                 </div>
 
                 <div className="space-y-1">
@@ -224,10 +234,14 @@ function TransactionsPage() {
                     onChange={(e) =>
                       setForm((f) => ({ ...f, type: e.target.value as 'EXPENSE' | 'INCOME' }))
                     }
+                    className={getCreateFieldError('type') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
                   >
                     <option value="EXPENSE">Expense</option>
                     <option value="INCOME">Income</option>
                   </Select>
+                  {getCreateFieldError('type') && (
+                    <p className="text-[10px] font-medium text-destructive">{getCreateFieldError('type')}</p>
+                  )}
                 </div>
 
                 <div className="space-y-1">
@@ -235,6 +249,7 @@ function TransactionsPage() {
                   <Select
                     value={form.currency}
                     onChange={(e) => setForm((f) => ({ ...f, currency: e.target.value }))}
+                    className={getCreateFieldError('currency') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
                   >
                     {CURRENCIES.map((c) => (
                       <option key={c} value={c}>
@@ -242,6 +257,9 @@ function TransactionsPage() {
                       </option>
                     ))}
                   </Select>
+                  {getCreateFieldError('currency') && (
+                    <p className="text-[10px] font-medium text-destructive">{getCreateFieldError('currency')}</p>
+                  )}
                 </div>
 
                 <div className="space-y-1">
@@ -251,7 +269,11 @@ function TransactionsPage() {
                     value={form.date}
                     onChange={(e) => setForm((f) => ({ ...f, date: e.target.value }))}
                     required
+                    className={getCreateFieldError('date') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
                   />
+                  {getCreateFieldError('date') && (
+                    <p className="text-[10px] font-medium text-destructive">{getCreateFieldError('date')}</p>
+                  )}
                 </div>
 
                 {categories.length > 0 && (
@@ -260,6 +282,7 @@ function TransactionsPage() {
                     <Select
                       value={form.categoryId}
                       onChange={(e) => setForm((f) => ({ ...f, categoryId: e.target.value }))}
+                      className={getCreateFieldError('categoryId') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
                     >
                       <option value="">No category</option>
                       {categories.map((c) => (
@@ -268,11 +291,14 @@ function TransactionsPage() {
                         </option>
                       ))}
                     </Select>
+                    {getCreateFieldError('categoryId') && (
+                      <p className="text-[10px] font-medium text-destructive">{getCreateFieldError('categoryId')}</p>
+                    )}
                   </div>
                 )}
               </div>
 
-              {createTx.isError && (
+              {createTx.isError && !createFieldErrors?.length && (
                 <p className="text-sm text-destructive">Failed to create transaction.</p>
               )}
 
@@ -378,6 +404,9 @@ function TransactionEditRow({
   onDone: () => void
 }) {
   const update = useUpdateTransaction(transaction.id)
+  const updateFieldErrors = (update.error as any)?.errors as Array<{ field: string; message: string }> | undefined
+  const getUpdateFieldError = (field: string) => updateFieldErrors?.find((e) => e.field === field)?.message
+
   const [form, setForm] = useState({
     description: transaction.description ?? '',
     amount: (transaction.amount / 100).toFixed(2),
@@ -406,49 +435,78 @@ function TransactionEditRow({
     <li className="px-4 py-3">
       <form onSubmit={handleSave} className="space-y-2">
         <div className="grid grid-cols-2 gap-2">
-          <div className="col-span-2">
+          <div className="col-span-2 space-y-1">
             <Input
               placeholder="Description"
               value={form.description}
               onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+              className={getUpdateFieldError('description') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
             />
+            {getUpdateFieldError('description') && (
+              <p className="text-[10px] font-medium text-destructive">{getUpdateFieldError('description')}</p>
+            )}
           </div>
-          <Input
-            type="number"
-            step="0.01"
-            min="0.01"
-            value={form.amount}
-            onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))}
-            required
-          />
-          <Select
-            value={form.type}
-            onChange={(e) => setForm((f) => ({ ...f, type: e.target.value as 'EXPENSE' | 'INCOME' }))}
-          >
-            <option value="EXPENSE">Expense</option>
-            <option value="INCOME">Income</option>
-          </Select>
-          <Select
-            value={form.currency}
-            onChange={(e) => setForm((f) => ({ ...f, currency: e.target.value }))}
-          >
-            {CURRENCIES.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
-            ))}
-          </Select>
-          <Input
-            type="date"
-            value={form.date}
-            onChange={(e) => setForm((f) => ({ ...f, date: e.target.value }))}
-            required
-          />
+          <div className="space-y-1">
+            <Input
+              type="number"
+              step="0.01"
+              min="0.01"
+              value={form.amount}
+              onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))}
+              required
+              className={getUpdateFieldError('amount') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
+            />
+            {getUpdateFieldError('amount') && (
+              <p className="text-[10px] font-medium text-destructive">{getUpdateFieldError('amount')}</p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <Select
+              value={form.type}
+              onChange={(e) => setForm((f) => ({ ...f, type: e.target.value as 'EXPENSE' | 'INCOME' }))}
+              className={getUpdateFieldError('type') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
+            >
+              <option value="EXPENSE">Expense</option>
+              <option value="INCOME">Income</option>
+            </Select>
+            {getUpdateFieldError('type') && (
+              <p className="text-[10px] font-medium text-destructive">{getUpdateFieldError('type')}</p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <Select
+              value={form.currency}
+              onChange={(e) => setForm((f) => ({ ...f, currency: e.target.value }))}
+              className={getUpdateFieldError('currency') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
+            >
+              {CURRENCIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </Select>
+            {getUpdateFieldError('currency') && (
+              <p className="text-[10px] font-medium text-destructive">{getUpdateFieldError('currency')}</p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <Input
+              type="date"
+              value={form.date}
+              onChange={(e) => setForm((f) => ({ ...f, date: e.target.value }))}
+              required
+              className={getUpdateFieldError('date') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
+            />
+            {getUpdateFieldError('date') && (
+              <p className="text-[10px] font-medium text-destructive">{getUpdateFieldError('date')}</p>
+            )}
+          </div>
           {categories.length > 0 && (
-            <div className="col-span-2">
+            <div className="col-span-2 space-y-1">
               <Select
                 value={form.categoryId}
                 onChange={(e) => setForm((f) => ({ ...f, categoryId: e.target.value }))}
+                className={getUpdateFieldError('categoryId') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
               >
                 <option value="">No category</option>
                 {categories.map((c) => (
@@ -457,11 +515,14 @@ function TransactionEditRow({
                   </option>
                 ))}
               </Select>
+              {getUpdateFieldError('categoryId') && (
+                <p className="text-[10px] font-medium text-destructive">{getUpdateFieldError('categoryId')}</p>
+              )}
             </div>
           )}
         </div>
 
-        {update.isError && (
+        {update.isError && !updateFieldErrors?.length && (
           <p className="text-xs text-destructive">Failed to save changes.</p>
         )}
 

--- a/src/routes/_auth/login.lazy.tsx
+++ b/src/routes/_auth/login.lazy.tsx
@@ -19,7 +19,8 @@ function LoginPage() {
 
   const login = useMutation({
     mutationFn: async (body: LoginRequest) => {
-      const { data } = await loginUser({ body })
+      const { data, error } = await loginUser({ body })
+      if (error) throw error
       return data as AuthToken
     },
     onSuccess: (data) => {
@@ -27,6 +28,9 @@ function LoginPage() {
       navigate({ to: '/' })
     },
   })
+
+  const fieldErrors = (login.error as any)?.errors as Array<{ field: string; message: string }> | undefined
+  const getFieldError = (field: string) => fieldErrors?.find((e) => e.field === field)?.message
 
   return (
     <div className="space-y-4">
@@ -53,7 +57,11 @@ function LoginPage() {
             onChange={(e) => setUsername(e.target.value)}
             autoComplete="username"
             required
+            className={getFieldError('username') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
           />
+          {getFieldError('username') && (
+            <p className="text-sm font-medium text-destructive">{getFieldError('username')}</p>
+          )}
         </div>
 
         <div className="space-y-1">
@@ -67,10 +75,14 @@ function LoginPage() {
             onChange={(e) => setPassword(e.target.value)}
             autoComplete="current-password"
             required
+            className={getFieldError('password') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
           />
+          {getFieldError('password') && (
+            <p className="text-sm font-medium text-destructive">{getFieldError('password')}</p>
+          )}
         </div>
 
-        {login.isError && (
+        {login.isError && !fieldErrors?.length && (
           <p className="text-sm text-destructive">Invalid credentials. Please try again.</p>
         )}
 

--- a/src/routes/_auth/register.lazy.tsx
+++ b/src/routes/_auth/register.lazy.tsx
@@ -17,12 +17,16 @@ function RegisterPage() {
 
   const register = useMutation({
     mutationFn: async (body: RegisterRequest) => {
-      await registerUser({ body })
+      const { error } = await registerUser({ body })
+      if (error) throw error
     },
     onSuccess: () => {
       navigate({ to: '/login' })
     },
   })
+
+  const fieldErrors = (register.error as any)?.errors as Array<{ field: string; message: string }> | undefined
+  const getFieldError = (field: string) => fieldErrors?.find((e) => e.field === field)?.message
 
   return (
     <div className="space-y-4">
@@ -51,7 +55,11 @@ function RegisterPage() {
             minLength={3}
             maxLength={50}
             required
+            className={getFieldError('username') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
           />
+          {getFieldError('username') && (
+            <p className="text-sm font-medium text-destructive">{getFieldError('username')}</p>
+          )}
         </div>
 
         <div className="space-y-1">
@@ -66,10 +74,14 @@ function RegisterPage() {
             autoComplete="new-password"
             minLength={8}
             required
+            className={getFieldError('password') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
           />
+          {getFieldError('password') && (
+            <p className="text-sm font-medium text-destructive">{getFieldError('password')}</p>
+          )}
         </div>
 
-        {register.isError && (
+        {register.isError && !fieldErrors?.length && (
           <p className="text-sm text-destructive">
             Registration failed. The username may already be taken.
           </p>


### PR DESCRIPTION
### Summary
- Integrated the new `FieldError` schema from contracts to display human-readable, field-specific validation errors across all forms.
- Improved accessibility by adding `aria-label` to icon-only buttons.

### Changes
- Updated `@budget-buddy-org/budget-buddy-contracts` to version `2.2.0` to include the `FieldError` schema.
- Modified mutation hooks in `useCategories.ts` and `useTransactions.ts` to throw API errors, enabling components to access the detailed `Problem` response.
- Updated `LoginPage`, `RegisterPage`, `CategoriesPage`, and `TransactionsPage` to extract and display field-specific error messages under their respective inputs.
- Added `aria-label` to "Delete" and "Theme Switch" buttons to comply with accessibility guidelines.

### Verification
- Created a reproduction test that mocks a 400 Validation Error with `FieldError`s and verified they are rendered in the UI.
- Ran all existing unit and integration tests (`useCategories`, `useTransactions`, `login.lazy.test.tsx`).
- Executed accessibility tests (`pnpm test:a11y`) and confirmed 100% pass rate.