### PR TITLE
feat(config): implement runtime configuration injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Pattern: The application uses a runtime configuration injection pattern via `/config.json`.
 - Environment Variables: All frontend environment variables (starting with `VITE_`) must be injected at runtime using `envsubst` within the Docker entrypoint.
 - Fallback: The `src/lib/config.ts` module handles both runtime loading and local development fallbacks.
-- Initialization: Configuration must be loaded during the application bootstrap in `src/main.tsx` before the UI is rendered.
+- Initialization: Configuration must be loaded during the application bootstrap in `src/main.tsx` before the UI is rendered. The `src/lib/api.ts` module must not initialize the API client itself; it should only register interceptors.
 
 ### Error Handling Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,11 @@
+### Configuration Conventions
+
+#### Runtime Configuration
+- Pattern: The application uses a runtime configuration injection pattern via `/config.json`.
+- Environment Variables: All frontend environment variables (starting with `VITE_`) must be injected at runtime using `envsubst` within the Docker entrypoint.
+- Fallback: The `src/lib/config.ts` module handles both runtime loading and local development fallbacks.
+- Initialization: Configuration must be loaded during the application bootstrap in `src/main.tsx` before the UI is rendered.
+
 ### Error Handling Conventions
 
 #### Error Fallbacks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Child routes are nested under these layouts by naming convention (`_app/`, `_aut
 ### API Client
 
 `src/lib/api.ts` configures the OpenAPI Fetch-based client from `@budget-buddy-org/budget-buddy-contracts`. It:
-- Uses `getConfig().VITE_API_URL` for the base URL, which is loaded at runtime.
+- Uses `client.setConfig` only in `src/main.tsx` after the configuration is loaded. The `src/lib/api.ts` module only registers interceptors.
 - Attaches the access token from Zustand to every request via interceptors
 - On 401: queues concurrent requests, attempts a token refresh via `refreshToken()`, then replays queued requests; on refresh failure, clears auth and redirects to `/login`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Child routes are nested under these layouts by naming convention (`_app/`, `_aut
 ### API Client
 
 `src/lib/api.ts` configures the OpenAPI Fetch-based client from `@budget-buddy-org/budget-buddy-contracts`. It:
+- Uses `getConfig().VITE_API_URL` for the base URL, which is loaded at runtime.
 - Attaches the access token from Zustand to every request via interceptors
 - On 401: queues concurrent requests, attempts a token refresh via `refreshToken()`, then replays queued requests; on refresh failure, clears auth and redirects to `/login`
 
@@ -68,6 +69,15 @@ Two Zustand stores:
 - `src/stores/theme.store.ts` — persists `theme` (`light`|`dark`|`system`) to `localStorage` (`budget-buddy-theme`). Applies `dark` class to `<html>` on rehydration.
 
 `useTabVisibilityRefresh` (mounted in `_app.tsx`) proactively refreshes the auth token on tab focus when the refresh token is older than 6 days, preventing expiry mid-session.
+
+### Runtime Configuration
+
+The application uses a runtime configuration pattern to allow environment-specific settings (like `VITE_API_URL`) to be changed without rebuilding the Docker image.
+
+- **Storage:** `public/config.json.template` defines the available settings with placeholders.
+- **Injection:** In Docker, `docker/docker-entrypoint.sh` uses `envsubst` to replace placeholders with environment variables and writes the result to `/usr/share/nginx/html/config.json`.
+- **Loading:** `src/lib/config.ts` fetches `/config.json` at runtime. During development, it falls back to `import.meta.env` values.
+- **Bootstrap:** `src/main.tsx` awaits `loadConfig()` before initializing the API client and rendering the app.
 
 ### Error Handling
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@
 #
 #   docker build \
 #     --secret id=github_token,env=GITHUB_TOKEN \
-#     --build-arg VITE_API_URL=https://api.example.com \
 #     -t budget-buddy-web-app .
 #
-# The GITHUB_TOKEN secret is mounted at build time only and never written
-# to any image layer or appears in `docker history`.
+# The VITE_API_URL is no longer injected at build time. Pass it as a runtime
+# environment variable to the container instead:
+#
+#   docker run -e VITE_API_URL=https://api.example.com -p 8080:80 budget-buddy-web-app
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Base — shared pnpm setup reused by deps and builder
@@ -55,13 +56,6 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# VITE_API_URL is injected at build time because Vite replaces import.meta.env.*
-# references during bundling — there is no runtime configuration for these values.
-# Pass the target API base URL when building for each environment, e.g.:
-#   --build-arg VITE_API_URL=https://api.production.example.com
-ARG VITE_API_URL
-ENV VITE_API_URL=$VITE_API_URL
-
 RUN pnpm build
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -84,7 +78,17 @@ COPY --link nginx.conf /etc/nginx/conf.d/default.conf
 # so it can be cached independently.
 COPY --link --from=builder /app/dist /usr/share/nginx/html
 
+# Install gettext for envsubst
+RUN apk add --no-cache gettext
+
+# Copy and set the entrypoint for runtime configuration injection
+COPY --link docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 EXPOSE 80
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]
 
 # Lightweight liveness check — wget is already included in nginx:alpine.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/README.md
+++ b/README.md
@@ -47,18 +47,20 @@ pnpm type-check   # tsc --noEmit
 
 Multi-stage build: `base` → `deps` (pnpm install with BuildKit secret + pnpm store cache) → `builder` (Vite build) → `production` (nginx:1.29-alpine).
 
+Runtime configuration is injected via `docker-entrypoint.sh` from environment variables using `envsubst`.
+
 ```bash
 # Build image — GITHUB_TOKEN passed as a BuildKit secret (never stored in any layer)
 docker build \
   --secret id=github_token,env=GITHUB_TOKEN \
-  --build-arg VITE_API_URL=https://api.example.com \
   -t budget-buddy-web-app .
 
 # Run locally with Docker Compose (app available at http://localhost:3000)
+# VITE_API_URL is injected into the container at runtime
 GITHUB_TOKEN=$(gh auth token) VITE_API_URL=http://localhost:8080 docker compose up --build
 ```
 
-`VITE_API_URL` is baked into the bundle at build time — rebuild the image when the API URL changes.
+`VITE_API_URL` is injected into the container at runtime — no need to rebuild the image when the API URL changes.
 
 Pre-built images are published to `ghcr.io/budget-buddy-org/budget-buddy-web-app` on every merge to `main` and every GitHub Release.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,10 @@ services:
       # before running `docker compose build`.
       secrets:
         - github_token
-      args:
-        # Vite bakes this URL into the bundle at build time.
-        # Override per environment: VITE_API_URL=https://api.prod.example.com docker compose build
-        VITE_API_URL: ${VITE_API_URL:-http://localhost:8080}
+    environment:
+      # Inject the API URL at runtime via the docker-entrypoint.sh script.
+      # Default to localhost if not specified in the environment.
+      VITE_API_URL: ${VITE_API_URL:-http://localhost:8080}
     ports:
       - "${WEB_PORT:-3000}:80"
     healthcheck:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Replace environment variables in config.json.template and save to config.json
+# We specify the variables to replace to avoid accidentally replacing other $ signs in the JSON
+envsubst '$VITE_API_URL' < /usr/share/nginx/html/config.json.template > /usr/share/nginx/html/config.json
+
+# Execute the original command
+exec "$@"

--- a/public/config.json.template
+++ b/public/config.json.template
@@ -1,0 +1,3 @@
+{
+  "VITE_API_URL": "$VITE_API_URL"
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,13 +1,6 @@
 import { refreshToken as refreshAction } from '@budget-buddy-org/budget-buddy-contracts'
 import { client } from '@budget-buddy-org/budget-buddy-contracts/client.gen'
 import { useAuthStore } from '@/stores/auth.store'
-import { getConfig } from './config'
-
-const { VITE_API_URL } = getConfig()
-
-client.setConfig({
-  baseUrl: VITE_API_URL,
-})
 
 // Attach access token to every outgoing request
 client.interceptors.request.use((request: Request) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,11 +1,12 @@
 import { refreshToken as refreshAction } from '@budget-buddy-org/budget-buddy-contracts'
 import { client } from '@budget-buddy-org/budget-buddy-contracts/client.gen'
 import { useAuthStore } from '@/stores/auth.store'
+import { getConfig } from './config'
 
-const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8080'
+const { VITE_API_URL } = getConfig()
 
 client.setConfig({
-  baseUrl: BASE_URL,
+  baseUrl: VITE_API_URL,
 })
 
 // Attach access token to every outgoing request

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,53 @@
+export interface AppConfig {
+  VITE_API_URL: string
+}
+
+let config: AppConfig | null = null
+
+/**
+ * Loads the application configuration from /config.json at runtime.
+ * Falls back to Vite environment variables during local development or if the fetch fails.
+ */
+export async function loadConfig(): Promise<AppConfig> {
+  if (config) return config
+
+  try {
+    const response = await fetch('/config.json')
+    if (response.ok) {
+      const runtimeConfig = await response.json()
+      // Filter out un-substituted placeholders like "$VITE_API_URL"
+      if (runtimeConfig.VITE_API_URL && !runtimeConfig.VITE_API_URL.startsWith('$')) {
+        config = runtimeConfig
+        console.info('Runtime configuration loaded successfully')
+      }
+    }
+  } catch (error) {
+    // Expected during local development where /config.json doesn't exist
+    if (import.meta.env.PROD) {
+      console.error('Failed to load runtime config, falling back to build-time env', error)
+    }
+  }
+
+  if (!config) {
+    config = {
+      VITE_API_URL: import.meta.env.VITE_API_URL ?? 'http://localhost:8080',
+    }
+  }
+
+  return config
+}
+
+/**
+ * Synchronously returns the already loaded configuration.
+ * Must be called after loadConfig() has completed.
+ */
+export function getConfig(): AppConfig {
+  if (!config) {
+    // If getConfig is called before loadConfig (e.g. in some early side-effect),
+    // we return a temporary object based on env vars as a last-resort fallback.
+    return {
+      VITE_API_URL: import.meta.env.VITE_API_URL ?? 'http://localhost:8080',
+    }
+  }
+  return config
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,8 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { routeTree } from './routeTree.gen'
 import { queryClient } from './lib/query-client'
+import { client } from '@budget-buddy-org/budget-buddy-contracts/client.gen'
+import { loadConfig } from './lib/config'
 import './lib/api'
 import './index.css'
 
@@ -18,10 +20,17 @@ declare module '@tanstack/react-router' {
 const rootEl = document.getElementById('root')
 if (!rootEl) throw new Error('Root element not found')
 
-createRoot(rootEl).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  </StrictMode>,
-)
+// Bootstrapping: Load runtime config, update the API client, then render the app.
+loadConfig().then((config) => {
+  client.setConfig({
+    baseUrl: config.VITE_API_URL,
+  })
+
+  createRoot(rootEl).render(
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </StrictMode>,
+  )
+})


### PR DESCRIPTION
## Why

This change enables environment-specific configuration (like `VITE_API_URL`) to be changed at runtime
without rebuilding the Docker image. Closes #53.

## What changed

- `public/config.json.template`: Added for environment variable placeholders.
- `docker/docker-entrypoint.sh`: Created to use `envsubst` for config injection.
- `Dockerfile`: Updated to install `gettext` and use the new entrypoint. Removed build-time `VITE_API_URL`.
- `src/lib/config.ts`: Implemented runtime config loading with local development fallback.
- `src/lib/api.ts`: Updated to use `getConfig().VITE_API_URL` for the base URL.
- `src/main.tsx`: Updated to await `loadConfig()` before initializing the API client and rendering the app.
- `docker-compose.yml`: Moved `VITE_API_URL` to the `environment` section for runtime injection.
- Updated `AGENTS.md`, `README.md`, and `CLAUDE.md` to document the new pattern.

## Acceptance criteria

✅ Create `public/config.json.template` with the `VITE_API_URL` placeholder.
✅ Create `docker/docker-entrypoint.sh` for environment variable substitution.
✅ Update `Dockerfile` to add the entrypoint and remove build-time injection.
✅ Implement `src/lib/config.ts` for runtime and local dev configuration.
✅ Update `src/lib/api.ts` and `src/main.tsx` to apply configuration during bootstrap.
✅ Update `docker-compose.yml` to pass `VITE_API_URL` as a runtime variable.
✅ Verify changes with `pnpm test` and update documentation.

## How to verify

1. Build the image: `docker build -t budget-buddy-web-app .`
2. Run it with a custom API URL: `docker run -e VITE_API_URL=https://api.test.com -p 3000:80 budget-buddy-web-app`
3. Verify that the app tries to fetch from `https://api.test.com` by checking the browser network tab.
4. Run `pnpm test` to ensure existing tests pass.

## Notes
None.