### PR TITLE
Implement proactive token refresh on application bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,8 @@
 - Component: Use `ConfirmationDialog` for all destructive actions like deleting data.
 - Styling: The confirm button should use `variant="destructive"` to provide visual warning.
 - Content: Always clearly state what is being deleted and that the action cannot be undone.
+
+### Authentication Conventions
+#### Token Lifecycle
+- Proactive Refresh: Re-authenticate during the bootstrap phase in `src/main.tsx` if a `refreshToken` exists but an `accessToken` is missing. This maintains session continuity across page reloads.
+- Centralized Refresh: Use the `refreshAuth` function in `src/lib/api.ts` for both the `401` response interceptor and manual/proactive refresh calls.

--- a/src/auth-refresh.test.ts
+++ b/src/auth-refresh.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useAuthStore } from './stores/auth.store'
+
+// Mocking the router redirect
+vi.mock('@tanstack/react-router', () => ({
+  redirect: vi.fn((obj) => obj),
+  createFileRoute: vi.fn(() => ({
+    beforeLoad: vi.fn(),
+  })),
+}))
+
+vi.mock('@budget-buddy-org/budget-buddy-contracts', () => ({
+  refreshToken: vi.fn(),
+}))
+
+describe('Auth rehydration on page reload', () => {
+  it('should be unauthenticated if only refreshToken is present after reload', () => {
+    useAuthStore.setState({
+      accessToken: null,
+      refreshToken: 'valid-refresh-token',
+      refreshTokenObtainedAt: Date.now(),
+    })
+
+    expect(useAuthStore.getState().isAuthenticated()).toBe(false)
+  })
+
+  it('should be authenticated after refreshAuth is called', async () => {
+    const { refreshToken: refreshAction } = await import('@budget-buddy-org/budget-buddy-contracts')
+    vi.mocked(refreshAction).mockResolvedValue({
+      data: { access_token: 'at-new', refresh_token: 'rt-new' },
+    } as any)
+
+    useAuthStore.setState({
+      accessToken: null,
+      refreshToken: 'rt-old',
+      refreshTokenObtainedAt: Date.now(),
+    })
+
+    const { refreshAuth } = await import('./lib/api')
+    await refreshAuth()
+
+    expect(useAuthStore.getState().accessToken).toBe('at-new')
+    expect(useAuthStore.getState().refreshToken).toBe('rt-new')
+    expect(useAuthStore.getState().isAuthenticated()).toBe(true)
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,6 +20,35 @@ function flushQueue(error: unknown, token: string | null) {
   pendingQueue = []
 }
 
+export async function refreshAuth() {
+  const refreshTokenValue = useAuthStore.getState().refreshToken
+  if (!refreshTokenValue) {
+    useAuthStore.getState().clearAuth()
+    return null
+  }
+
+  isRefreshing = true
+  try {
+    const { data } = await refreshAction({
+      body: { refresh_token: refreshTokenValue },
+    })
+
+    if (!data) {
+      throw new Error('Refresh failed')
+    }
+
+    useAuthStore.getState().setAuth(data.access_token, data.refresh_token)
+    flushQueue(null, data.access_token)
+    return data.access_token
+  } catch (refreshError) {
+    flushQueue(refreshError, null)
+    useAuthStore.getState().clearAuth()
+    return null
+  } finally {
+    isRefreshing = false
+  }
+}
+
 // On 401: attempt refresh → retry; on refresh failure → clear auth + redirect to login
 client.interceptors.response.use(async (response: Response, _request: Request, options: any) => {
   if (response.status !== 401 || options._retry) {
@@ -36,41 +65,17 @@ client.interceptors.response.use(async (response: Response, _request: Request, o
     })
   }
 
-  const refreshTokenValue = useAuthStore.getState().refreshToken
-  if (!refreshTokenValue) {
-    useAuthStore.getState().clearAuth()
-    if (typeof window !== 'undefined') {
-      window.location.href = '/login'
-    }
-    return response
-  }
-
   options._retry = true
-  isRefreshing = true
+  const token = await refreshAuth()
 
-  try {
-    const { data } = await refreshAction({
-      body: { refresh_token: refreshTokenValue },
-    })
-
-    if (!data) {
-      throw new Error('Refresh failed')
-    }
-
-    useAuthStore.getState().setAuth(data.access_token, data.refresh_token)
-    flushQueue(null, data.access_token)
-
-    const newHeaders = new Headers(options.headers)
-    newHeaders.set('Authorization', `Bearer ${data.access_token}`)
-    return client.request({ ...options, headers: newHeaders } as any).then((r: any) => r.response)
-  } catch (refreshError) {
-    flushQueue(refreshError, null)
-    useAuthStore.getState().clearAuth()
+  if (!token) {
     if (typeof window !== 'undefined') {
       window.location.href = '/login'
     }
     return response
-  } finally {
-    isRefreshing = false
   }
+
+  const newHeaders = new Headers(options.headers)
+  newHeaders.set('Authorization', `Bearer ${token}`)
+  return client.request({ ...options, headers: newHeaders } as any).then((r: any) => r.response)
 })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,8 @@ import { routeTree } from './routeTree.gen'
 import { queryClient } from './lib/query-client'
 import { client } from '@budget-buddy-org/budget-buddy-contracts/client.gen'
 import { loadConfig } from './lib/config'
-import './lib/api'
+import { refreshAuth } from './lib/api'
+import { useAuthStore } from './stores/auth.store'
 import './index.css'
 
 const router = createRouter({ routeTree })
@@ -21,10 +22,17 @@ const rootEl = document.getElementById('root')
 if (!rootEl) throw new Error('Root element not found')
 
 // Bootstrapping: Load runtime config, update the API client, then render the app.
-loadConfig().then((config) => {
+loadConfig().then(async (config) => {
   client.setConfig({
     baseUrl: config.VITE_API_URL,
   })
+
+  // Try to refresh the token on app load if we have a refresh token but no access token.
+  // This avoids unnecessary redirects to the login page on page reload.
+  const { accessToken, refreshToken } = useAuthStore.getState()
+  if (!accessToken && refreshToken) {
+    await refreshAuth()
+  }
 
   createRoot(rootEl).render(
     <StrictMode>


### PR DESCRIPTION
## Why

Users who refreshed their page were often redirected to the login screen, even if they had a valid `refreshToken` in `localStorage`, because the `accessToken` was only held in memory. This PR ensures that the application attempts to re-authenticate using the refresh token during its initial bootstrap phase, providing a smoother user experience.

## What changed

- **Refactored `src/lib/api.ts`**: Extracted the token refresh logic into a reusable `refreshAuth` function, enabling it to be triggered both by a `401` response interceptor and by the application's bootstrap logic.
- **Enhanced Bootstrap Logic in `src/main.tsx`**: Added an asynchronous call to `refreshAuth` during the app's initialization if a refresh token is present but an access token is not.
- **Updated `401` Interceptor**: Modified the response interceptor to use the new centralized `refreshAuth` function.
- **Added Automated Tests**: Created `src/auth-refresh.test.ts` to verify that the authentication state is correctly rehydrated after calling the refresh logic.

## Acceptance criteria

- [x] Application re-authenticates automatically on page reload if a valid refresh token exists.
- [x] Concurrent `401` errors are still handled correctly via the existing request queue.
- [x] No "flash of login page" occurs for authenticated users on reload.
- [x] All unit and integration tests pass.

## How to verify

1. Log in to the application.
2. Refresh the browser page.
3. Observe that you remain logged in and are not redirected to the `/login` page.
4. Verify that all tests pass by running `pnpm test`.

## Notes

- This change depends on the `useAuthStore`'s `isAuthenticated()` method, which has been verified to return `false` if `accessToken` is missing, even if `refreshToken` exists, necessitating the manual refresh call during bootstrap.