### PR TITLE
fix(auth): fix infinite loop on 401 from refresh endpoint

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -122,7 +122,10 @@ describe('API response interceptor', () => {
 
     await responseInterceptor!(res, makeRequest(), opts)
 
-    expect(refreshToken).toHaveBeenCalledWith({ body: { refresh_token: 'rt-current' } })
+    expect(refreshToken).toHaveBeenCalledWith({
+      body: { refresh_token: 'rt-current' },
+      _isRefresh: true,
+    })
     expect(mockAuthState.setAuth).toHaveBeenCalledWith('at-new', 'rt-new')
     expect(mockClientRequest).toHaveBeenCalled()
   })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -31,7 +31,8 @@ export async function refreshAuth() {
   try {
     const { data } = await refreshAction({
       body: { refresh_token: refreshTokenValue },
-    })
+      _isRefresh: true,
+    } as any)
 
     if (!data) {
       throw new Error('Refresh failed')
@@ -51,7 +52,7 @@ export async function refreshAuth() {
 
 // On 401: attempt refresh → retry; on refresh failure → clear auth + redirect to login
 client.interceptors.response.use(async (response: Response, _request: Request, options: any) => {
-  if (response.status !== 401 || options._retry) {
+  if (response.status !== 401 || options._retry || options._isRefresh) {
     return response
   }
 


### PR DESCRIPTION
This PR fixes a deadlock that occurred when the authentication refresh endpoint returned a 401, causing an infinite loader.