### PR TITLE
fix(ui): ensure Button asChild receives only one child

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -47,8 +47,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={loading || disabled}
         {...props}
       >
-        {loading && <Loader2 className="h-4 w-4 animate-spin" />}
-        {children}
+        {asChild ? children : (
+          <>
+            {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+            {children}
+          </>
+        )}
       </Comp>
     )
   },


### PR DESCRIPTION
This Pull Request fixes a crash in the dashboard occurring when no transactions are present. The root cause was an issue in the `Button` component's `asChild` implementation, where multiple children (including a loading spinner) were incorrectly passed to the Radix UI `Slot`.

### Changes:
- Modified `src/components/ui/button.tsx` to ensure that when `asChild` is true, only `children` are passed to the `Slot`.
- Added a conditional check and fragment in the non-`asChild` branch to properly render the loading spinner.

### Verification:
- Created a reproduction test case for the `DashboardPage` that simulates an empty transaction list.
- Verified that the test failed before the fix and passed after.
- Ran existing a11y tests to ensure no regressions.