### PR TITLE
feat: improve dashboard, transaction grouping, and navigation

### DIFF
--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -24,7 +24,7 @@ export function PageHeader({ title, subtitle, primaryAction, children }: PageHea
       <div className="flex items-center justify-between gap-2">
         <div className="min-w-0">
           <h1 className="text-xl font-semibold">{title}</h1>
-          {subtitle && <div className="mt-1">{subtitle}</div>}
+          {subtitle && <div className="mt-1 text-sm text-muted-foreground">{subtitle}</div>}
         </div>
         <div className="flex items-center gap-2">
           {children}

--- a/src/components/transactions/TransactionForm.test.tsx
+++ b/src/components/transactions/TransactionForm.test.tsx
@@ -12,9 +12,11 @@ vi.mock('@/hooks/use-toast', () => ({
 
 const mockCreateTx = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false, error: null }
 const mockUpdateTx = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false, error: null }
+const mockDeleteTx = { mutate: vi.fn(), isPending: false }
 vi.mock('@/hooks/useTransactions', () => ({
   useCreateTransaction: () => mockCreateTx,
   useUpdateTransaction: () => mockUpdateTx,
+  useDeleteTransaction: () => mockDeleteTx,
 }))
 
 const mockCreateCategory = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false, error: null }
@@ -49,6 +51,21 @@ vi.mock('@/components/ui/transaction-type-toggle', () => ({
       React.createElement('button', { onClick: () => onChange('EXPENSE'), 'aria-pressed': value === 'EXPENSE' }, 'Expense'),
       React.createElement('button', { onClick: () => onChange('INCOME'), 'aria-pressed': value === 'INCOME' }, 'Income'),
     ),
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: any) => React.createElement('div', {}, children),
+  DropdownMenuTrigger: ({ children }: any) => React.createElement('div', {}, children),
+  DropdownMenuContent: ({ children }: any) => React.createElement('div', {}, children),
+  DropdownMenuItem: ({ children, onClick }: any) => React.createElement('button', { onClick }, children),
+}))
+
+vi.mock('@/components/ConfirmationDialog', () => ({
+  ConfirmationDialog: ({ isOpen, onConfirm, title }: any) => 
+    isOpen ? React.createElement('div', {}, 
+      React.createElement('span', {}, title),
+      React.createElement('button', { onClick: onConfirm }, 'Confirm Delete')
+    ) : null,
 }))
 
 const categories = [
@@ -130,5 +147,23 @@ describe('TransactionForm', () => {
       }),
       expect.any(Object)
     ))
+  })
+
+  it('shows delete confirmation and deletes transaction', async () => {
+    const onSuccess = vi.fn()
+    const transaction = { id: 'tx-1', description: 'Old Coffee', amount: 500, currency: 'EUR', type: 'EXPENSE', date: '2024-01-01' }
+    renderForm({ onSuccess, transaction })
+    const user = userEvent.setup()
+
+    // Open dropdown and click Remove
+    await user.click(screen.getByText(/Remove/i))
+
+    // Check if confirmation dialog is shown
+    expect(screen.getByText(/Delete Transaction/i)).toBeInTheDocument()
+
+    // Confirm delete
+    await user.click(screen.getByText(/Confirm Delete/i))
+
+    expect(mockDeleteTx.mutate).toHaveBeenCalledWith('tx-1', expect.any(Object))
   })
 })

--- a/src/components/transactions/TransactionForm.test.tsx
+++ b/src/components/transactions/TransactionForm.test.tsx
@@ -31,7 +31,7 @@ vi.mock('@/components/ui/button', () => ({
 }))
 vi.mock('@/components/ui/input', () => ({
   Input: ({ value, onChange, placeholder, autoFocus }: any) =>
-    React.createElement('input', { value, onChange, placeholder, autoFocus }),
+    React.createElement('input', { value, onChange, placeholder, 'data-autofocus': autoFocus }),
 }))
 vi.mock('@/components/ui/select', () => ({
   Select: ({ children, value, onChange }: any) =>
@@ -165,5 +165,17 @@ describe('TransactionForm', () => {
     await user.click(screen.getByText(/Confirm Delete/i))
 
     expect(mockDeleteTx.mutate).toHaveBeenCalledWith('tx-1', expect.any(Object))
+  })
+
+  it('handles autoFocus based on mode', () => {
+    const { unmount } = renderForm()
+    const createInput = screen.getByPlaceholderText(/Coffee/i)
+    expect(createInput).toHaveAttribute('data-autofocus', 'true')
+    unmount()
+
+    const transaction = { id: 'tx-1', description: 'Old Coffee', amount: 500, currency: 'EUR', type: 'EXPENSE', date: '2024-01-01' }
+    renderForm({ transaction })
+    const editInput = screen.getByPlaceholderText(/Coffee/i)
+    expect(editInput).toHaveAttribute('data-autofocus', 'false')
   })
 })

--- a/src/components/transactions/TransactionForm.tsx
+++ b/src/components/transactions/TransactionForm.tsx
@@ -157,7 +157,7 @@ export function TransactionForm({
 
   return (
     <>
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-4 animate-fade-in">
         {isEditing && (
           <div className="absolute top-4 right-4">
             <DropdownMenu>
@@ -208,7 +208,7 @@ export function TransactionForm({
                 value={form.description}
                 onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
                 className={getFieldError('description') ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
-                autoFocus
+                autoFocus={!isEditing}
               />
               {getFieldError('description') && (
                 <p className="text-[0.625rem] font-medium text-destructive">{getFieldError('description')}</p>
@@ -296,7 +296,7 @@ export function TransactionForm({
               </div>
 
               {isAddingCategory ? (
-                <div className="space-y-1">
+                <div className="space-y-1 animate-fade-in">
                   <Input
                     placeholder="New category name…"
                     value={newCategoryName}
@@ -317,7 +317,7 @@ export function TransactionForm({
                   )}
                 </div>
               ) : (
-                <>
+                <div className="space-y-1 animate-fade-in">
                   <Select
                     value={form.categoryId}
                     onChange={(e) => setForm((f) => ({ ...f, categoryId: e.target.value }))}
@@ -340,7 +340,7 @@ export function TransactionForm({
                       {getFieldError('categoryId')}
                     </p>
                   )}
-                </>
+                </div>
               )}
             </div>
           </div>

--- a/src/components/transactions/TransactionForm.tsx
+++ b/src/components/transactions/TransactionForm.tsx
@@ -4,13 +4,20 @@ import { AmountInput } from '@/components/ui/amount-input'
 import { DatePicker } from '@/components/ui/date-picker'
 import { Select } from '@/components/ui/select'
 import { TransactionTypeToggle } from '@/components/ui/transaction-type-toggle'
-import { useCreateTransaction, useUpdateTransaction } from '@/hooks/useTransactions'
+import { useCreateTransaction, useUpdateTransaction, useDeleteTransaction } from '@/hooks/useTransactions'
 import { useCreateCategory } from '@/hooks/useCategories'
 import { useToast } from '@/hooks/use-toast'
 import { toMinorUnits, todayIso } from '@/lib/formatters'
 import type { Transaction, TransactionWrite } from '@budget-buddy-org/budget-buddy-contracts'
-import { Check, X, Plus, RotateCcw } from 'lucide-react'
+import { Check, X, Plus, RotateCcw, MoreVertical, Trash2 } from 'lucide-react'
 import { useState } from 'react'
+import { ConfirmationDialog } from '@/components/ConfirmationDialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 const CURRENCIES = ['EUR', 'GBP', 'USD']
 
@@ -30,8 +37,10 @@ export function TransactionForm({
   const { toast } = useToast()
   const createTx = useCreateTransaction()
   const updateTx = useUpdateTransaction(transaction?.id ?? '')
+  const deleteTx = useDeleteTransaction()
   const createCategory = useCreateCategory()
 
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [form, setForm] = useState({
     description: transaction?.description ?? '',
     amount: transaction ? (transaction.amount / 100).toFixed(2) : '',
@@ -114,6 +123,27 @@ export function TransactionForm({
     })
   }
 
+  const handleDelete = () => {
+    if (!transaction?.id) return
+    deleteTx.mutate(transaction.id, {
+      onSuccess: () => {
+        toast({
+          title: 'Transaction deleted',
+          description: 'The transaction has been removed.',
+          variant: 'success',
+        })
+        onSuccess()
+      },
+      onError: () => {
+        toast({
+          title: 'Error',
+          description: 'Failed to delete transaction.',
+          variant: 'destructive',
+        })
+      },
+    })
+  }
+
   const isFormValid =
     !!form.type &&
     !!form.currency &&
@@ -126,8 +156,37 @@ export function TransactionForm({
   const isPending = currentMutation.isPending || createCategory.isPending
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {isEditing && (
+          <div className="absolute top-4 right-4">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                >
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="text-destructive focus:text-destructive cursor-pointer"
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Remove
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onCancel} className="cursor-pointer">
+                  <X className="h-4 w-4 mr-2" />
+                  Cancel
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="sm:col-span-2 space-y-1">
               <label className="text-xs font-medium text-muted-foreground">
                 Type <span className="text-destructive">*</span>
@@ -297,5 +356,17 @@ export function TransactionForm({
             </Button>
           </div>
     </form>
+
+      <ConfirmationDialog
+        isOpen={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+        onConfirm={handleDelete}
+        title="Delete Transaction"
+        description="Are you sure you want to delete this transaction? This action cannot be undone."
+        confirmText="Delete"
+        variant="destructive"
+        isLoading={deleteTx.isPending}
+      />
+    </>
   )
 }

--- a/src/components/transactions/TransactionList.test.tsx
+++ b/src/components/transactions/TransactionList.test.tsx
@@ -2,10 +2,6 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { TransactionList } from './TransactionList'
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/hooks/useTransactions', () => ({
-  useDeleteTransaction: () => ({ mutate: vi.fn(), isPending: false }),
-}))
-
 vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: vi.fn() }),
 }))
@@ -35,5 +31,25 @@ describe('TransactionList empty states', () => {
     
     fireEvent.click(resetButton)
     expect(onResetFilters).toHaveBeenCalled()
+  })
+
+  it('groups transactions by date', () => {
+    const transactions = [
+      { id: '1', description: 'Item 1', date: '2024-01-01', amount: 1000, currency: 'EUR', type: 'EXPENSE', categoryId: 'c1' },
+      { id: '2', description: 'Item 2', date: '2024-01-01', amount: 2000, currency: 'EUR', type: 'INCOME', categoryId: 'c1' },
+      { id: '3', description: 'Item 3', date: '2024-01-02', amount: 3000, currency: 'EUR', type: 'EXPENSE', categoryId: 'c1' },
+    ] as any[]
+    const categories = [{ id: 'c1', name: 'Category 1' }]
+    
+    render(<TransactionList transactions={transactions} categories={categories} isLoading={false} />)
+    
+    // Check if dates are rendered as headers (formatDate('2024-01-01') -> Jan 1, 2024)
+    expect(screen.getByText('Jan 1, 2024')).toBeInTheDocument()
+    expect(screen.getByText('Jan 2, 2024')).toBeInTheDocument()
+    
+    // Check if items are rendered
+    expect(screen.getByText('Item 1')).toBeInTheDocument()
+    expect(screen.getByText('Item 2')).toBeInTheDocument()
+    expect(screen.getByText('Item 3')).toBeInTheDocument()
   })
 })

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -2,15 +2,9 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { ConfirmationDialog } from '@/components/ConfirmationDialog'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { TransactionForm } from './TransactionForm'
-import { useDeleteTransaction } from '@/hooks/useTransactions'
-import { useToast } from '@/hooks/use-toast'
 import { formatCurrency, formatDate } from '@/lib/formatters'
 import type { Transaction } from '@budget-buddy-org/budget-buddy-contracts'
-import { Trash2 } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo } from 'react'
 
 interface TransactionListProps {
   transactions: Transaction[]
@@ -18,6 +12,7 @@ interface TransactionListProps {
   isLoading: boolean
   isFiltering?: boolean
   onResetFilters?: () => void
+  onEdit?: (id: string) => void
 }
 
 export function TransactionList({
@@ -26,43 +21,56 @@ export function TransactionList({
   isLoading,
   isFiltering = false,
   onResetFilters,
+  onEdit,
 }: TransactionListProps) {
-  const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null)
-  const [deleteId, setDeleteId] = useState<string | null>(null)
-  const { toast } = useToast()
-  const deleteTx = useDeleteTransaction()
-
   const categoryMap = Object.fromEntries(categories.map((c) => [c.id, c.name]))
 
-  const handleDelete = () => {
-    if (!deleteId) return
-    deleteTx.mutate(deleteId, {
-      onSuccess: () => {
-        setDeleteId(null)
-        toast({
-          title: 'Transaction deleted',
-          description: 'The transaction has been removed.',
-          variant: 'success',
-        })
-      },
-      onError: () => {
-        toast({
-          title: 'Error',
-          description: 'Failed to delete transaction.',
-          variant: 'destructive',
-        })
-      },
-    })
-  }
+  const groupedTransactions = useMemo(() => {
+    const groups: { date: string; items: Transaction[] }[] = []
+    let currentGroup: { date: string; items: Transaction[] } | null = null
+
+    for (const t of transactions) {
+      if (!currentGroup || currentGroup.date !== t.date) {
+        currentGroup = { date: t.date, items: [] }
+        groups.push(currentGroup)
+      }
+      currentGroup.items.push(t)
+    }
+    return groups
+  }, [transactions])
 
   if (isLoading) {
     return (
+      <div className="space-y-4">
+        {[...Array(3)].map((_, i) => (
+          <Card key={i}>
+            <CardContent className="p-0">
+              <Skeleton className="h-7 w-full rounded-none" />
+              <div className="space-y-px p-2">
+                {[...Array(2)].map((_, j) => (
+                  <Skeleton key={j} className="h-14 rounded-sm" />
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    )
+  }
+
+  if (transactions.length === 0) {
+    return (
       <Card>
         <CardContent className="p-0">
-          <div className="space-y-px p-2">
-            {[...Array(5)].map((_, i) => (
-              <Skeleton key={i} className="h-14 rounded-sm" />
-            ))}
+          <div className="flex flex-col items-center justify-center gap-2 px-6 py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              {isFiltering ? 'No transactions match your filters.' : 'No transactions yet.'}
+            </p>
+            {isFiltering && onResetFilters && (
+              <Button variant="link" onClick={onResetFilters} className="h-auto p-0 text-primary">
+                Reset filters
+              </Button>
+            )}
           </div>
         </CardContent>
       </Card>
@@ -71,87 +79,40 @@ export function TransactionList({
 
   return (
     <>
-      <Card>
-        <CardContent className="p-0">
-          {transactions.length === 0 ? (
-            <div className="flex flex-col items-center justify-center gap-2 px-6 py-8 text-center">
-              <p className="text-sm text-muted-foreground">
-                {isFiltering ? 'No transactions match your filters.' : 'No transactions yet.'}
-              </p>
-              {isFiltering && onResetFilters && (
-                <Button variant="link" onClick={onResetFilters} className="h-auto p-0 text-primary">
-                  Reset filters
-                </Button>
-              )}
-            </div>
-          ) : (
-            <ul className="divide-y">
-              {transactions.map((t) => (
-                <li
-                  key={t.id}
-                  className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/30 cursor-pointer"
-                >
-                  <button
-                    type="button"
-                    className="min-w-0 flex-1 text-left focus-visible:outline-none cursor-pointer"
-                    onClick={() => setEditingTransaction(t)}
+      <div className="space-y-4">
+        {groupedTransactions.map((group) => (
+          <Card key={group.date}>
+            <CardContent className="p-0">
+              <div className="bg-muted/30 px-4 py-1.5 text-xs font-semibold text-muted-foreground sticky top-0 z-10 backdrop-blur-sm">
+                {formatDate(group.date)}
+              </div>
+              <ul className="divide-y">
+                {group.items.map((t) => (
+                  <li
+                    key={t.id}
+                    className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/30 cursor-pointer"
                   >
-                    <p className="truncate text-sm font-medium">{t.description ?? '—'}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {formatDate(t.date)}
-                      {categoryMap[t.categoryId ?? ''] ? ` · ${categoryMap[t.categoryId!]}` : ''}
-                    </p>
-                  </button>
-                  <Badge variant={t.type === 'INCOME' ? 'income' : 'expense'}>
-                    {t.type === 'INCOME' ? '+' : '-'}
-                    {formatCurrency(t.amount, t.currency)}
-                  </Badge>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
-                    onClick={() => setDeleteId(t.id)}
-                    disabled={deleteTx.isPending && deleteId === t.id}
-                    aria-label="Delete transaction"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </CardContent>
-      </Card>
-
-      <ConfirmationDialog
-        isOpen={!!deleteId}
-        onOpenChange={(open) => !open && setDeleteId(null)}
-        onConfirm={handleDelete}
-        title="Delete Transaction"
-        description="Are you sure you want to delete this transaction? This action cannot be undone."
-        confirmText="Delete"
-        variant="destructive"
-        isLoading={deleteTx.isPending}
-      />
-
-      <Dialog open={!!editingTransaction} onOpenChange={(open) => !open && setEditingTransaction(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Transaction</DialogTitle>
-            <DialogDescription>
-              Update your transaction details including amount, date, and category.
-            </DialogDescription>
-          </DialogHeader>
-          {editingTransaction && (
-            <TransactionForm
-              categories={categories}
-              transaction={editingTransaction}
-              onSuccess={() => setEditingTransaction(null)}
-              onCancel={() => setEditingTransaction(null)}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+                    <button
+                      type="button"
+                      className="min-w-0 flex-1 text-left focus-visible:outline-none cursor-pointer"
+                      onClick={() => onEdit?.(t.id)}
+                    >
+                      <p className="truncate text-sm font-medium">{t.description ?? '—'}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {categoryMap[t.categoryId ?? ''] ? categoryMap[t.categoryId!] : 'No Category'}
+                      </p>
+                    </button>
+                    <Badge variant={t.type === 'INCOME' ? 'income' : 'expense'}>
+                      {t.type === 'INCOME' ? '+' : '-'}
+                      {formatCurrency(t.amount, t.currency)}
+                    </Badge>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </>
   )
 }

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -41,7 +41,7 @@ export function TransactionList({
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-4 animate-fade-in">
         {[...Array(3)].map((_, i) => (
           <Card key={i}>
             <CardContent className="p-0">

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -12,7 +12,7 @@ const badgeVariants = cva(
         destructive: 'border-transparent bg-destructive text-destructive-foreground',
         outline: 'text-foreground',
         income: 'border-transparent bg-income/15 text-income',
-        expense: 'border-transparent bg-expense/15 text-expense',
+        expense: 'border-transparent bg-muted text-foreground',
       },
     },
     defaultVariants: { variant: 'default' },

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -5,7 +5,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm overflow-hidden', className)}
       {...props}
     />
   ),

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -29,8 +29,8 @@ DialogOverlay.displayName = DialogPrimitives.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitives.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitives.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitives.Content> & { hideClose?: boolean }
+>(({ className, children, hideClose, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitives.Content
@@ -47,10 +47,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitives.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground cursor-pointer">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitives.Close>
+      {!hideClose && (
+        <DialogPrimitives.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground cursor-pointer">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitives.Close>
+      )}
     </DialogPrimitives.Content>
   </DialogPortal>
 ))

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { cn } from '@/lib/cn'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPortal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPortal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 cursor-pointer',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+}

--- a/src/components/ui/transaction-type-toggle.tsx
+++ b/src/components/ui/transaction-type-toggle.tsx
@@ -31,7 +31,7 @@ export function TransactionTypeToggle({
         className={cn(
           'flex-1 flex items-center justify-center gap-2 px-3 rounded-md text-sm font-medium transition-all cursor-pointer select-none outline-none',
           value === 'EXPENSE'
-            ? 'bg-background text-expense shadow-sm'
+            ? 'bg-background text-foreground shadow-sm'
             : 'text-muted-foreground hover:text-foreground hover:bg-background/50'
         )}
       >

--- a/src/hooks/useTransactions.test.ts
+++ b/src/hooks/useTransactions.test.ts
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useCreateTransaction, useDeleteTransaction, useTransactions } from './useTransactions'
+import { useCreateTransaction, useDeleteTransaction, useTransactions, useAllTransactions } from './useTransactions'
 import {
   listTransactions,
   createTransaction,
@@ -50,14 +50,88 @@ describe('useTransactions', () => {
     vi.clearAllMocks()
   })
 
-  it('returns fetched transactions', async () => {
-    vi.mocked(listTransactions).mockResolvedValue({ data: mockPage } as any)
+  it('returns fetched transactions and requests one more page', async () => {
+    vi.mocked(listTransactions)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: 'tx-1', date: '2024-01-10' }],
+          meta: { total: 100, size: 20, page: 0 }
+        }
+      } as any)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: 'tx-2', date: '2024-01-09' }],
+          meta: { total: 100, size: 20, page: 1 }
+        }
+      } as any)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: 'tx-3', date: '2024-01-08' }],
+          meta: { total: 100, size: 20, page: 2 }
+        }
+      } as any)
 
     const { result } = renderHook(() => useTransactions(), { wrapper: makeWrapper() })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data?.items).toHaveLength(1)
-    expect(result.current.data?.items[0]?.description).toBe('Coffee')
+    // It should have called listTransactions 3 times (page 0, page 1 (min 2 pages), page 2 (to check split))
+    // But only items from page 0 and 1 should be included as page 1 and 2 are not split.
+    expect(result.current.data?.items).toHaveLength(2)
+    expect(listTransactions).toHaveBeenCalledTimes(3)
+  })
+
+  it('continues fetching if day is split', async () => {
+    vi.mocked(listTransactions)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: '1', date: '2024-01-10' }],
+          meta: { total: 100, size: 1, page: 0 }
+        }
+      } as any)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: '2', date: '2024-01-10' }],
+          meta: { total: 100, size: 1, page: 1 }
+        }
+      } as any)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: '3', date: '2024-01-10' }], // Split with page 1
+          meta: { total: 100, size: 1, page: 2 }
+        }
+      } as any)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: '4', date: '2024-01-09' }], // Not split with page 2
+          meta: { total: 100, size: 1, page: 3 }
+        }
+      } as any)
+
+    const { result } = renderHook(() => useTransactions(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    // Calls:
+    // 1. Page 0 (Added, fetchCount=1)
+    // 2. Page 1 (Added, fetchCount=2)
+    // 3. Page 2 (Split with 1, Added, fetchCount=3)
+    // 4. Page 3 (Not split with 2, Broken)
+    expect(listTransactions).toHaveBeenCalledTimes(4)
+    expect(result.current.data?.items).toHaveLength(3)
+  })
+
+  it('stops at 10 page fetches', async () => {
+    vi.mocked(listTransactions).mockResolvedValue({
+      data: {
+        items: [{ id: 'x', date: '2024-01-10' }],
+        meta: { total: 100, size: 1, page: 0 }
+      }
+    } as any)
+
+    const { result } = renderHook(() => useTransactions(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(listTransactions).toHaveBeenCalledTimes(10)
+    expect(result.current.data?.items).toHaveLength(10)
   })
 
   it('passes filters to the API', async () => {
@@ -72,6 +146,52 @@ describe('useTransactions', () => {
     expect(listTransactions).toHaveBeenCalledWith(
       expect.objectContaining({ query: expect.objectContaining({ categoryId: 'cat-1', sort: 'asc', size: 10 }) }),
     )
+  })
+})
+
+describe('useAllTransactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches multiple pages until total is reached', async () => {
+    vi.mocked(listTransactions)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: '1' }],
+          meta: { total: 2, size: 1, page: 0 }
+        }
+      } as any)
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ id: '2' }],
+          meta: { total: 2, size: 1, page: 1 }
+        }
+      } as any)
+
+    const { result } = renderHook(() => useAllTransactions(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.items).toHaveLength(2)
+    expect(listTransactions).toHaveBeenCalledTimes(2)
+    expect(listTransactions).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ query: expect.objectContaining({ page: 0, size: 200 }) }),
+    )
+  })
+
+  it('limits to 10 page fetches', async () => {
+    vi.mocked(listTransactions).mockResolvedValue({
+      data: {
+        items: [{ id: '1' }],
+        meta: { total: 100, size: 1, page: 0 }
+      }
+    } as any)
+
+    const { result } = renderHook(() => useAllTransactions(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(listTransactions).toHaveBeenCalledTimes(10)
   })
 })
 

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -32,15 +32,72 @@ export function useTransactions(filters: TransactionFilters = {}) {
   return useQuery({
     queryKey: KEYS.list(filters),
     queryFn: async () => {
-      const { data, error } = await listTransactions({
-        query: {
-          size: 20,
-          sort: 'desc',
-          ...filters,
-        },
-      })
-      if (error) throw error
-      return data
+      let allItems: any[] = []
+      const page = filters.page ?? 0
+      const size = filters.size ?? 20
+      let total = 0
+      let fetchCount = 0
+
+      while (fetchCount < 10) {
+        const { data, error } = await listTransactions({
+          query: {
+            size,
+            sort: 'desc',
+            ...filters,
+            page: page + fetchCount,
+          },
+        })
+        if (error) throw error
+
+        if (fetchCount === 0) {
+          total = data.meta.total
+        }
+
+        const newItems = data.items
+        if (newItems.length === 0) break
+
+        // Always add the first two pages (initial requested + one more)
+        // OR if the day is split (last item of current batch has same date as first item of next page)
+        const isSplit = allItems.length > 0 && allItems[allItems.length - 1].date === newItems[0].date
+
+        if (fetchCount < 2 || isSplit) {
+          allItems = [...allItems, ...newItems]
+          fetchCount++
+          if (allItems.length >= total) break
+        } else {
+          break
+        }
+      }
+
+      return { items: allItems, meta: { total } }
+    },
+  })
+}
+
+export function useAllTransactions(filters: TransactionFilters = {}) {
+  return useQuery({
+    queryKey: [...KEYS.list(filters), 'all'],
+    queryFn: async () => {
+      let allItems: any[] = []
+      let page = 0
+      let total = 0
+      const size = 200
+
+      do {
+        const { data, error } = await listTransactions({
+          query: {
+            ...filters,
+            size,
+            page,
+          },
+        })
+        if (error) throw error
+        allItems = [...allItems, ...data.items]
+        total = data.meta.total
+        page++
+      } while (allItems.length < total && page < 10)
+
+      return { items: allItems, meta: { total } }
     },
   })
 }

--- a/src/routes/_app/categories/index.lazy.test.tsx
+++ b/src/routes/_app/categories/index.lazy.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@/components/ui/card', () => ({
 }))
 vi.mock('@/components/ui/input', () => ({
   Input: ({ value, onChange, placeholder, className, autoFocus, maxLength }: any) =>
-    React.createElement('input', { value, onChange, placeholder, className, autoFocus, maxLength }),
+    React.createElement('input', { value, onChange, placeholder, className, 'data-autofocus': autoFocus, maxLength }),
 }))
 vi.mock('@/components/ui/skeleton', () => ({
   Skeleton: ({ className }: any) => React.createElement('div', { 'data-testid': 'skeleton', className }),
@@ -259,5 +259,26 @@ describe('CategoriesPage', () => {
     await user.click(confirmBtn)
 
     expect(mockDeleteCategory.mutate).toHaveBeenCalledWith('cat-1', expect.any(Object))
+  })
+
+  it('handles autoFocus correctly in dialogs', async () => {
+    vi.mocked(useCategories).mockReturnValue({
+      data: {
+        items: [{ id: 'cat-1', name: 'Groceries' }],
+        meta: { total: 1, size: 200, page: 0 },
+      },
+      isLoading: false,
+    } as any)
+    renderPage()
+    const user = userEvent.setup()
+
+    // Add dialog
+    await user.click(screen.getByRole('button', { name: /Add/i }))
+    expect(screen.getByPlaceholderText(/New category name/i)).toHaveAttribute('data-autofocus', 'true')
+    await user.click(screen.getByRole('button', { name: /Cancel/i }))
+
+    // Edit dialog
+    await user.click(screen.getByText('Groceries'))
+    expect(screen.getByPlaceholderText(/Category name/i)).not.toHaveAttribute('data-autofocus')
   })
 })

--- a/src/routes/_app/categories/index.lazy.tsx
+++ b/src/routes/_app/categories/index.lazy.tsx
@@ -130,9 +130,10 @@ function CategoriesPage() {
     : allCategories
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6 animate-fade-in">
       <PageHeader
         title="Categories"
+        subtitle="Manage categories to organize your transactions."
         primaryAction={{
           label: 'Add',
           onClick: () => setShowForm((v) => !v),

--- a/src/routes/_app/categories/index.lazy.tsx
+++ b/src/routes/_app/categories/index.lazy.tsx
@@ -160,7 +160,7 @@ function CategoriesPage() {
               Create a new category to group your transactions.
             </DialogDescription>
           </DialogHeader>
-          <form onSubmit={handleCreate} className="space-y-4">
+          <form onSubmit={handleCreate} className="space-y-4 animate-fade-in">
             <div className="space-y-1">
               <label className="text-xs font-medium text-muted-foreground">
                 Name <span className="text-destructive">*</span>
@@ -200,7 +200,7 @@ function CategoriesPage() {
               Modify the name of your category.
             </DialogDescription>
           </DialogHeader>
-          <form onSubmit={handleUpdate} className="space-y-4">
+          <form onSubmit={handleUpdate} className="space-y-4 animate-fade-in">
             <div className="space-y-1">
               <label className="text-xs font-medium text-muted-foreground">
                 Name <span className="text-destructive">*</span>
@@ -210,7 +210,6 @@ function CategoriesPage() {
                 value={editName}
                 onChange={(e) => setEditName(e.target.value)}
                 maxLength={255}
-                autoFocus
                 autoComplete="off"
                 className={updateFieldError ? 'border-destructive ring-destructive focus-visible:ring-destructive' : ''}
               />
@@ -240,7 +239,7 @@ function CategoriesPage() {
       <Card>
         <CardContent className="p-0">
           {isLoading ? (
-            <div className="space-y-px p-2">
+            <div className="space-y-px p-2 animate-fade-in">
               {[...Array(4)].map((_, i) => (
                 <Skeleton key={i} className="h-11 rounded-sm" />
               ))}

--- a/src/routes/_app/index.a11y.test.tsx
+++ b/src/routes/_app/index.a11y.test.tsx
@@ -23,8 +23,8 @@ vi.mock('recharts', () => ({
   Cell: () => null,
 }))
 
-vi.mock('@/hooks/useTransactions', () => ({
-  useTransactions: () => ({
+vi.mock('@/hooks/useTransactions', () => {
+  const mockData = {
     data: {
       items: [
         {
@@ -48,8 +48,12 @@ vi.mock('@/hooks/useTransactions', () => ({
       ],
     },
     isLoading: false,
-  }),
-}))
+  }
+  return {
+    useTransactions: () => mockData,
+    useAllTransactions: () => mockData,
+  }
+})
 
 describe('DashboardPage a11y', () => {
   it('should have no accessibility violations', async () => {

--- a/src/routes/_app/index.lazy.test.tsx
+++ b/src/routes/_app/index.lazy.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { Route } from './index.lazy'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type React from 'react'
+import { useNavigate } from '@tanstack/react-router'
+
+vi.mock('@tanstack/react-router', () => ({
+  createLazyFileRoute: () => (options: any) => ({ options }),
+  useNavigate: vi.fn(),
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+  BarChart: ({ children }: any) => <div>{children}</div>,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Cell: () => null,
+}))
+
+const mockTransactions = [
+  {
+    id: '1',
+    description: 'Income this month',
+    amount: 10000,
+    type: 'INCOME',
+    currency: 'EUR',
+    date: '2026-04-10',
+    categoryId: '1',
+  },
+  {
+    id: '2',
+    description: 'Expense this month',
+    amount: 5000,
+    type: 'EXPENSE',
+    currency: 'EUR',
+    date: '2026-04-11',
+    categoryId: '2',
+  },
+  {
+    id: '3',
+    description: 'Income last month',
+    amount: 20000,
+    type: 'INCOME',
+    currency: 'EUR',
+    date: '2026-03-20',
+    categoryId: '1',
+  },
+]
+
+vi.mock('@/hooks/useTransactions', () => ({
+  useAllTransactions: vi.fn(),
+}))
+
+import { useAllTransactions } from '@/hooks/useTransactions'
+
+describe('DashboardPage', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-14'))
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('calculates totals based on current month only', async () => {
+    ;(useAllTransactions as any).mockReturnValue({
+      data: {
+        items: mockTransactions,
+      },
+      isLoading: false,
+    })
+
+    const DashboardPage = (Route as any).options.component as React.ElementType
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DashboardPage />
+      </QueryClientProvider>
+    )
+
+    // Current month: 2026-04
+    // Items: 10000 income, 5000 expense. Balance = 50.00
+
+    // Income card
+    const incomeCard = screen.getByText('Income').closest('.rounded-lg')
+    expect(incomeCard).toHaveTextContent(/100/)
+
+    // Expense card
+    const expenseCard = screen.getByText('Expenses').closest('.rounded-lg')
+    expect(expenseCard).toHaveTextContent(/50/)
+
+    // Balance card
+    const balanceCard = screen.getByText('Balance').closest('.rounded-lg')
+    expect(balanceCard).toHaveTextContent(/50/)
+  })
+
+  it('navigates to edit transaction on click', async () => {
+    const mockNavigate = vi.fn()
+    ;(useNavigate as any).mockReturnValue(mockNavigate)
+    ;(useAllTransactions as any).mockReturnValue({
+      data: {
+        items: mockTransactions,
+      },
+      isLoading: false,
+    })
+
+    const DashboardPage = (Route as any).options.component as React.ElementType
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DashboardPage />
+      </QueryClientProvider>
+    )
+
+    const transactionItem = screen.getByText('Income this month')
+    fireEvent.click(transactionItem)
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/transactions',
+      search: expect.objectContaining({ edit: '1' }),
+    })
+  })
+})

--- a/src/routes/_app/index.lazy.tsx
+++ b/src/routes/_app/index.lazy.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useTransactions } from '@/hooks/useTransactions'
+import { useAllTransactions } from '@/hooks/useTransactions'
 import { formatCurrency, formatDate } from '@/lib/formatters'
 import { PageHeader } from '@/components/layout/PageHeader'
 
@@ -14,17 +14,28 @@ export const Route = createLazyFileRoute('/_app/')({
   component: DashboardPage,
 })
 
-const SUMMARY_LIMIT = 50
-
 function DashboardPage() {
   const navigate = useNavigate()
-  const { data, isLoading } = useTransactions({ size: SUMMARY_LIMIT, sort: 'desc' })
+  
+  // Calculate date range for the last 6 months to support the chart
+  const now = new Date()
+  const currentMonth = now.toISOString().slice(0, 7)
+  const sixMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 5, 1)
+  const startDate = sixMonthsAgo.toISOString().split('T')[0]
+
+  const { data, isLoading } = useAllTransactions({ 
+    start: startDate,
+    sort: 'desc' 
+  })
 
   if (isLoading) return <DashboardSkeleton />
 
   const transactions = data?.items ?? []
 
-  const totals = transactions.reduce(
+  // Current month summary
+  const currentMonthTransactions = transactions.filter((t) => t.date.startsWith(currentMonth))
+  
+  const totals = currentMonthTransactions.reduce(
     (acc, t) => {
       if (t.type === 'INCOME') acc.income += t.amount
       else acc.expense += t.amount
@@ -52,10 +63,10 @@ function DashboardPage() {
   const recent = transactions.slice(0, 8)
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-fade-in">
       <PageHeader
         title="Dashboard"
-        subtitle={<span className="text-xs text-muted-foreground">Last {SUMMARY_LIMIT} items</span>}
+        subtitle="Current month summary"
         primaryAction={{
           label: 'Add',
           onClick: () => navigate({ to: '/transactions', search: { add: 'true' } as any }),
@@ -133,23 +144,29 @@ function DashboardPage() {
                 </p>
               </div>
               <Button asChild size="sm">
-                <Link to="/transactions" search={{ add: undefined }}>Add transaction</Link>
+                <Link to="/transactions" search={{ add: undefined, edit: undefined } as any}>Add transaction</Link>
               </Button>
             </div>
           ) : (
             <ul className="divide-y">
               {recent.map((t) => (
-                <li key={t.id} className="flex items-center justify-between px-6 py-3">
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-medium">{t.description ?? '—'}</p>
-                    <p className="text-xs text-muted-foreground">{formatDate(t.date)}</p>
-                  </div>
-                  <div className="ml-4 flex items-center gap-2">
-                    <Badge variant={t.type === 'INCOME' ? 'income' : 'expense'}>
-                      {t.type === 'INCOME' ? '+' : '-'}
-                      {formatCurrency(t.amount, t.currency)}
-                    </Badge>
-                  </div>
+                <li key={t.id}>
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between px-6 py-3 transition-colors hover:bg-muted/30 cursor-pointer text-left focus-visible:outline-none"
+                    onClick={() => navigate({ to: '/transactions', search: { edit: t.id } as any })}
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">{t.description ?? '—'}</p>
+                      <p className="text-xs text-muted-foreground">{formatDate(t.date)}</p>
+                    </div>
+                    <div className="ml-4 flex items-center gap-2">
+                      <Badge variant={t.type === 'INCOME' ? 'income' : 'expense'}>
+                        {t.type === 'INCOME' ? '+' : '-'}
+                        {formatCurrency(t.amount, t.currency)}
+                      </Badge>
+                    </div>
+                  </button>
                 </li>
               ))}
             </ul>

--- a/src/routes/_app/index.lazy.tsx
+++ b/src/routes/_app/index.lazy.tsx
@@ -179,7 +179,7 @@ function DashboardPage() {
 
 function DashboardSkeleton() {
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-fade-in">
       <Skeleton className="h-7 w-32" />
       <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
         <Skeleton className="col-span-2 h-24 md:col-span-1" />

--- a/src/routes/_app/settings.lazy.tsx
+++ b/src/routes/_app/settings.lazy.tsx
@@ -3,7 +3,6 @@ import { useThemeStore } from '@/stores/theme.store'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { PageHeader } from '@/components/layout/PageHeader'
-import { Separator } from '@/components/ui/separator'
 import { Moon, Sun, Monitor, Type, Palette, RefreshCw } from 'lucide-react'
 
 export const Route = createLazyFileRoute('/_app/settings')({
@@ -17,10 +16,8 @@ function SettingsPage() {
     <div className="space-y-6 animate-fade-in">
       <PageHeader
         title="Settings"
-        subtitle={<span className="text-muted-foreground">Manage your application appearance and preferences.</span>}
+        subtitle="Manage your application appearance and preferences."
       />
-
-      <Separator />
 
       <div className="grid gap-6">
         <section className="space-y-3">

--- a/src/routes/_app/transactions/index.a11y.test.tsx
+++ b/src/routes/_app/transactions/index.a11y.test.tsx
@@ -51,6 +51,7 @@ vi.mock('@/hooks/useTransactions', () => ({
   useCreateTransaction: () => ({ mutate: vi.fn(), isPending: false }),
   useDeleteTransaction: () => ({ mutate: vi.fn(), isPending: false }),
   useUpdateTransaction: () => ({ mutate: vi.fn(), isPending: false }),
+  useTransaction: () => ({ data: null, isLoading: false }),
 }))
 
 describe('TransactionsPage a11y', () => {

--- a/src/routes/_app/transactions/index.lazy.test.tsx
+++ b/src/routes/_app/transactions/index.lazy.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { Route } from './index.lazy'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type React from 'react'
+
+const mockNavigate = vi.fn()
+const mockUseSearch = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  createLazyFileRoute: () => (options: any) => ({ options }),
+  useNavigate: () => mockNavigate,
+  useSearch: () => mockUseSearch(),
+}))
+
+vi.mock('@/hooks/useTransactions', () => ({
+  useTransactions: vi.fn(),
+  useTransaction: vi.fn(),
+}))
+
+vi.mock('@/hooks/useCategories', () => ({
+  useCategories: vi.fn(),
+}))
+
+vi.mock('@/components/transactions/TransactionForm', () => ({
+  TransactionForm: ({ transaction, onSuccess }: any) => (
+    <div data-testid="transaction-form">
+      {transaction ? `Editing ${transaction.id}` : 'Adding'}
+      <button onClick={onSuccess}>Success</button>
+    </div>
+  ),
+}))
+
+import { useTransactions, useTransaction } from '@/hooks/useTransactions'
+import { useCategories } from '@/hooks/useCategories'
+
+describe('TransactionsPage', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(useCategories as any).mockReturnValue({ data: { items: [] }, isLoading: false })
+    ;(useTransactions as any).mockReturnValue({ data: { items: [], meta: { total: 0 } }, isLoading: false })
+    ;(useTransaction as any).mockReturnValue({ data: null, isLoading: false })
+  })
+
+  it('opens edit dialog when edit search param is present', async () => {
+    mockUseSearch.mockReturnValue({ edit: '123' })
+    ;(useTransaction as any).mockReturnValue({ 
+      data: { id: '123', description: 'Test', amount: 1000, date: '2024-01-01' }, 
+      isLoading: false 
+    })
+
+    const TransactionsPage = (Route as any).options.component as React.ElementType
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TransactionsPage />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByText('Edit Transaction')).toBeInTheDocument()
+    expect(screen.getByTestId('transaction-form')).toHaveTextContent('Editing 123')
+  })
+
+  it('opens add dialog when add search param is present', async () => {
+    mockUseSearch.mockReturnValue({ add: 'true' })
+    
+    const TransactionsPage = (Route as any).options.component as React.ElementType
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TransactionsPage />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByText('Add Transaction')).toBeInTheDocument()
+    expect(screen.getByTestId('transaction-form')).toHaveTextContent('Adding')
+  })
+})

--- a/src/routes/_app/transactions/index.lazy.tsx
+++ b/src/routes/_app/transactions/index.lazy.tsx
@@ -155,7 +155,7 @@ function TransactionsPage() {
             </DialogDescription>
           </DialogHeader>
           {isTransactionLoading && search.edit ? (
-            <div className="space-y-4 py-4">
+            <div className="space-y-4 py-4 animate-fade-in">
               <Skeleton className="h-10 w-full" />
               <Skeleton className="h-10 w-full" />
               <Skeleton className="h-10 w-full" />

--- a/src/routes/_app/transactions/index.lazy.tsx
+++ b/src/routes/_app/transactions/index.lazy.tsx
@@ -3,8 +3,9 @@ import { Filter } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useCategories } from '@/hooks/useCategories'
-import { useTransactions } from '@/hooks/useTransactions'
+import { useTransactions, useTransaction } from '@/hooks/useTransactions'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { Pagination } from '@/components/ui/pagination'
 import { TransactionFilters } from '@/components/transactions/TransactionFilters'
@@ -25,6 +26,7 @@ function TransactionsPage() {
 
   const [showForm, setShowForm] = useState(false)
   const [showFilters, setShowFilters] = useState(false)
+  const { data: editingTransaction, isLoading: isTransactionLoading } = useTransaction(search.edit!)
 
   useEffect(() => {
     if (search.add === 'true') {
@@ -36,6 +38,16 @@ function TransactionsPage() {
       })
     }
   }, [search.add, navigate])
+
+  const closeForm = () => {
+    setShowForm(false)
+    if (search.edit) {
+      navigate({
+        search: { edit: undefined } as any,
+        replace: true,
+      })
+    }
+  }
 
   const [filters, setFilters] = useState<{
     categoryId: string
@@ -95,9 +107,10 @@ function TransactionsPage() {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6 animate-fade-in">
       <PageHeader
         title="Transactions"
+        subtitle="View and manage your income and expenses."
         primaryAction={{
           label: 'Add',
           onClick: () => setShowForm((v) => !v),
@@ -131,19 +144,30 @@ function TransactionsPage() {
         </DialogContent>
       </Dialog>
       
-      <Dialog open={showForm} onOpenChange={setShowForm}>
-        <DialogContent>
+      <Dialog open={showForm || !!search.edit} onOpenChange={(open) => !open && closeForm()}>
+        <DialogContent hideClose={!!search.edit}>
           <DialogHeader>
-            <DialogTitle>Add Transaction</DialogTitle>
+            <DialogTitle>{search.edit ? 'Edit Transaction' : 'Add Transaction'}</DialogTitle>
             <DialogDescription>
-              Record a new expense or income to track your budget.
+              {search.edit
+                ? 'Update your transaction details including amount, date, and category.'
+                : 'Record a new expense or income to track your budget.'}
             </DialogDescription>
           </DialogHeader>
-          <TransactionForm
-            categories={categories}
-            onSuccess={() => setShowForm(false)}
-            onCancel={() => setShowForm(false)}
-          />
+          {isTransactionLoading && search.edit ? (
+            <div className="space-y-4 py-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : (showForm || (search.edit && editingTransaction)) ? (
+            <TransactionForm
+              categories={categories}
+              transaction={search.edit ? editingTransaction : undefined}
+              onSuccess={closeForm}
+              onCancel={closeForm}
+            />
+          ) : null}
         </DialogContent>
       </Dialog>
 
@@ -153,6 +177,7 @@ function TransactionsPage() {
         isLoading={isLoading}
         isFiltering={isFiltered}
         onResetFilters={resetFilters}
+        onEdit={(id) => (navigate as any)({ search: (s: any) => ({ ...s, edit: id }) })}
       />
 
       {!isLoading && transactions.length > 0 && (

--- a/src/routes/_app/transactions/index.tsx
+++ b/src/routes/_app/transactions/index.tsx
@@ -3,5 +3,6 @@ import { createFileRoute } from '@tanstack/react-router'
 export const Route = createFileRoute('/_app/transactions/')({
   validateSearch: (search: Record<string, unknown>) => ({
     add: (search.add as string) || undefined,
+    edit: (search.edit as string) || undefined,
   }),
 })


### PR DESCRIPTION
Summary of changes:
- Implement transaction grouping by date with sticky headers
- Group daily transactions into separate cards
- Update dashboard to calculate summary based on current month
- Implement multi-page fetching (up to 10 pages) for transactions
- Move deletion logic to edit form with three-dots menu
- Align page titles and standardize PageHeader styling
- Implement routing-based transaction edit mode (support direct linking)
- Add comprehensive tests for new dashboard and transaction features
- Add smooth fade-in animations for forms and loading skeletons
- Disable autofocus when opening transaction or category for editing