### PR TITLE
fix(auth): use router.navigate instead of window.location on 401

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,14 +48,18 @@ Child routes are nested under these layouts by naming convention (`_app/`, `_aut
 
 **Test colocation in routes:** The router plugin is configured with `routeFileIgnorePattern: '\\.test\\.tsx?$'`, so test files (`*.test.tsx`) placed inside `src/routes/` are excluded from the generated route tree. This allows tests to live next to the route file they test.
 
+**Search parameter validation:** `validateSearch` uses explicit `typeof` checks rather than a Zod schema. This is intentional — Zod is not a project dependency, and the schemas are small enough that manual guards are clearer and have zero overhead. Do not add Zod just for URL param validation.
+
 ### API Client
 
 `src/lib/api.ts` configures the OpenAPI Fetch-based client from `@budget-buddy-org/budget-buddy-contracts`. It:
 - Uses `client.setConfig` only in `src/main.tsx` after the configuration is loaded. The `src/lib/api.ts` module only registers interceptors to ensure the global client is correctly configured before first use.
 - Attaches the access token from Zustand to every request via interceptors
-- On 401: queues concurrent requests, attempts a token refresh via `refreshToken()`, then replays queued requests; on refresh failure, clears auth and redirects to `/login`
+- On 401: queues concurrent requests, attempts a token refresh via `refreshToken()`, then replays queued requests; on refresh failure, clears auth and navigates to `/login` via the router (not `window.location.href` — that would discard React Query cache and all in-memory state)
 
 The application uses standalone functional API calls (e.g. `listTransactions`, `createCategory`) exported directly from the contracts package, which share the configured global client.
+
+**Router module:** The router is created in `src/lib/router.ts` (not `main.tsx`) so that `api.ts` can import it for programmatic navigation without creating a circular dependency. `main.tsx` imports the router from there too.
 
 ### Server State
 

--- a/src/auth-refresh.test.ts
+++ b/src/auth-refresh.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { useAuthStore } from './stores/auth.store';
 
+vi.mock('@/lib/router', () => ({
+  router: { navigate: vi.fn() },
+}));
+
 // Mocking the router redirect
 vi.mock('@tanstack/react-router', () => ({
   redirect: vi.fn((obj) => obj),

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -10,6 +10,12 @@ type RefreshTokenResult = Awaited<ReturnType<typeof refreshToken>>;
 
 const mockClientRequest = vi.fn();
 
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+
+vi.mock('@/lib/router', () => ({
+  router: { navigate: mockNavigate },
+}));
+
 vi.mock('@budget-buddy-org/budget-buddy-contracts/client.gen', () => ({
   client: {
     setConfig: vi.fn(),
@@ -63,6 +69,7 @@ function makeRequest(url = 'http://localhost/test'): Request {
 describe('API response interceptor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockNavigate.mockReset();
     mockAuthState = {
       accessToken: null,
       refreshToken: 'rt-current',
@@ -119,43 +126,21 @@ describe('API response interceptor', () => {
     // where the bootstrap sequence will retry the refresh on reload.
     vi.mocked(refreshToken).mockRejectedValue(new Error('network error'));
 
-    const hrefSetter = vi.fn();
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: {
-        ...window.location,
-        set href(v: string) {
-          hrefSetter(v);
-        },
-      },
-    });
-
     const res = makeResponse(401);
     await responseInterceptor?.(res, makeRequest(), {});
 
     expect(mockAuthState.clearAuth).not.toHaveBeenCalled();
-    expect(hrefSetter).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('clears auth and redirects to /login when there is no refresh token', async () => {
     mockAuthState.refreshToken = null;
 
-    const hrefSetter = vi.fn();
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: {
-        ...window.location,
-        set href(v: string) {
-          hrefSetter(v);
-        },
-      },
-    });
-
     const res = makeResponse(401);
     await responseInterceptor?.(res, makeRequest(), {});
 
     expect(mockAuthState.clearAuth).toHaveBeenCalled();
-    expect(hrefSetter).toHaveBeenCalledWith('/login');
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/login' });
   });
 
   it('queues concurrent 401s and replays them once the refresh resolves', async () => {
@@ -202,30 +187,15 @@ describe('API response interceptor', () => {
       error: undefined,
     } as unknown as RefreshTokenResult);
 
-    const hrefSetter = vi.fn();
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: {
-        ...window.location,
-        set href(v: string) {
-          hrefSetter(v);
-        },
-      },
-    });
-
     await responseInterceptor?.(makeResponse(401), makeRequest(), {});
 
     expect(mockAuthState.clearAuth).toHaveBeenCalled();
-    expect(hrefSetter).toHaveBeenCalledWith('/login');
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/login' });
   });
 
   it('does not leave isRefreshing=true after the no-refresh-token path (regression)', async () => {
     // First 401 with no refresh token — previously left isRefreshing=true
     mockAuthState.refreshToken = null;
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { ...window.location, set href(_v: string) {} },
-    });
     await responseInterceptor?.(makeResponse(401), makeRequest(), {});
 
     // Second 401 — now has a refresh token; must attempt refresh, not hang

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { refreshToken as refreshAction } from '@budget-buddy-org/budget-buddy-contracts';
 import { client } from '@budget-buddy-org/budget-buddy-contracts/client.gen';
+import { router } from '@/lib/router';
 import { useAuthStore } from '@/stores/auth.store';
 
 export type InternalOptions = Parameters<typeof client.request>[0] & {
@@ -73,14 +74,6 @@ export function refreshAuth() {
   return refreshPromise;
 }
 
-function shouldRedirectToLogin() {
-  return (
-    typeof window !== 'undefined' &&
-    !window.location.pathname.includes('/login') &&
-    !window.location.pathname.includes('/register')
-  );
-}
-
 // On 401: attempt refresh → retry; on refresh failure → clear auth + redirect to login
 client.interceptors.response.use(
   async (response: Response, _request: Request, options: unknown) => {
@@ -113,8 +106,8 @@ client.interceptors.response.use(
 
     if (!token) {
       const { refreshToken } = useAuthStore.getState();
-      if (!refreshToken && shouldRedirectToLogin()) {
-        window.location.href = '/login';
+      if (!refreshToken) {
+        router.navigate({ to: '/login' });
       }
       return response;
     }

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,0 +1,16 @@
+import { createRouter } from '@tanstack/react-router';
+import { RouteLoader } from '@/components/layout/RouteLoader';
+import { routeTree } from '@/routeTree.gen';
+
+export const router = createRouter({
+  routeTree,
+  defaultPendingComponent: RouteLoader,
+  defaultPendingMs: 100,
+  defaultPendingMinMs: 300,
+});
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,13 @@
 import { client } from '@budget-buddy-org/budget-buddy-contracts/client.gen';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { createRouter, RouterProvider } from '@tanstack/react-router';
+import { RouterProvider } from '@tanstack/react-router';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { RouteLoader } from './components/layout/RouteLoader';
 import { refreshAuth } from './lib/api';
 import { loadConfig } from './lib/config';
 import { logError } from './lib/error-logger';
 import { queryClient } from './lib/query-client';
-import { routeTree } from './routeTree.gen';
+import { router } from './lib/router';
 import { useAuthStore } from './stores/auth.store';
 import './index.css';
 
@@ -20,19 +19,6 @@ window.addEventListener('error', (event) => {
 window.addEventListener('unhandledrejection', (event) => {
   logError(event.reason, { source: 'UnhandledRejection' });
 });
-
-const router = createRouter({
-  routeTree,
-  defaultPendingComponent: RouteLoader,
-  defaultPendingMs: 100,
-  defaultPendingMinMs: 300,
-});
-
-declare module '@tanstack/react-router' {
-  interface Register {
-    router: typeof router;
-  }
-}
 
 const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('Root element not found');


### PR DESCRIPTION
## Why

When an auth refresh fails, the interceptor in `api.ts` was redirecting to `/login` via `window.location.href`. In a SPA this causes a full browser reload, discarding the React Query cache, router state, and any in-flight context — none of which needs to happen. Identified in issue #80 (Gemini code review).

## What changed

- **`src/lib/router.ts` (new)** — router creation extracted from `main.tsx` into its own module. This is necessary to break what would otherwise be a circular dependency: `main.tsx` already imports `api.ts` (via `refreshAuth`), so `api.ts` cannot import from `main.tsx`. A shared `router.ts` module solves this cleanly. The `Register` module augmentation lives here so TypeScript knows the full router type everywhere.
- **`src/lib/api.ts`** — replaces `window.location.href = '/login'` with `router.navigate({ to: '/login' })`, keeping the React tree alive across session expiry. Removed the now-redundant `shouldRedirectToLogin()` guard — TanStack Router's `_auth.tsx` layout already handles the redirect-loop case.
- **`src/main.tsx`** — imports `router` from `./lib/router` instead of creating it inline.
- **`CLAUDE.md`** — documents the router module split with the rationale, and explicitly notes that `validateSearch` uses manual `typeof` guards intentionally (no Zod dep; schemas are small).

## How to verify

1. `pnpm type-check` — passes with no errors
2. Sign in, then invalidate the refresh token in the DB (or clear just the `refreshToken` from `localStorage` while keeping `accessToken` expired)
3. Make any API call — the interceptor should attempt refresh, fail, clear auth, and navigate to `/login` without a full page reload (network tab shows no full document reload; React DevTools tree stays mounted)
4. Confirm you land on `/login` and can sign in again normally

## Notes

The other findings from the Gemini review (#80) were reviewed and intentionally dismissed: `validateSearch` manual guards are sufficient without Zod; `main.tsx` bootstrap complexity is deliberate (refresh-before-render prevents flash-to-login); `useAllTransactions` batch fetch is a documented architectural trade-off scoped to the Dashboard; `TransactionForm` props are not prop drilling.