### PR TITLE
ci: use native arm64 runner and parallel builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,14 +12,33 @@ permissions:
   id-token: write        # for keyless Cosign signing via OIDC
   security-events: write # for uploading SARIF scan results
 
+env:
+  IMAGE: ghcr.io/budget-buddy-org/budget-buddy-web-app
+
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  # ───────────────────────────────────────────────────────────────────────────
+  # Build per-platform images in parallel on native runners (no QEMU).
+  # Each job pushes a single-platform image by digest to the registry.
+  # ───────────────────────────────────────────────────────────────────────────
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            cache-scope: buildx-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            cache-scope: buildx-arm64
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      # Forward digests so downstream jobs can reference them.
+      # Each matrix leg writes to a unique output via its PLATFORM env.
+      digest-amd64: ${{ steps.build.outputs.digest }}
+      digest-arm64: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up QEMU (multi-platform emulation)
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -35,115 +54,145 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
-          images: ghcr.io/budget-buddy-org/budget-buddy-web-app
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+          images: ${{ env.IMAGE }}
 
-      # Build a single-platform (amd64) image locally so we can scan it
-      # before pushing anything to the registry. Reuse GHA cache to avoid
-      # rebuilding layers that haven't changed since the last push.
-      - name: Build image for scanning (amd64, no push)
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
-          platforms: linux/amd64
-          push: false
-          load: true
-          tags: ghcr.io/budget-buddy-org/budget-buddy-web-app:scan
-          build-args: VITE_API_URL=${{ vars.VITE_API_URL }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}
-          cache-from: type=gha
+          sbom: true
+          provenance: mode=max
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.cache-scope }}
+          cache-to: type=gha,scope=${{ matrix.cache-scope }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-${{ matrix.cache-scope }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Scan the amd64 image for vulnerabilities before creating the manifest.
+  # Runs in parallel with the arm64 build for maximum concurrency.
+  # ───────────────────────────────────────────────────────────────────────────
+  scan:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download amd64 digest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: digests-buildx-amd64
+          path: /tmp/digests
+
+      - name: Resolve digest
+        id: digest
+        run: echo "sha=sha256:$(ls /tmp/digests)" >> "$GITHUB_OUTPUT"
 
       # Scan CRITICAL+HIGH findings and upload to the Security tab for full
       # visibility. Non-blocking — HIGH findings appear as warnings only.
-      - name: Scan image with Trivy (amd64, SARIF)
+      - name: Scan image with Trivy (SARIF)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          image-ref: ghcr.io/budget-buddy-org/budget-buddy-web-app:scan
+          image-ref: ${{ env.IMAGE }}@${{ steps.digest.outputs.sha }}
           format: sarif
-          output: trivy-amd64.sarif
+          output: trivy.sarif
           exit-code: '0'
           severity: CRITICAL,HIGH
           ignore-unfixed: true
 
-      - name: Upload amd64 scan results to GitHub Security tab
+      - name: Upload scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         if: always()
         with:
-          sarif_file: trivy-amd64.sarif
+          sarif_file: trivy.sarif
           category: trivy-amd64
 
       # Blocking gate — fails the job only on unfixed CRITICAL CVEs.
       #
       # Deliberate policy: HIGH vulnerabilities do not block pushes.
-      # Rationale: nginx:1.29-alpine ships with 3 unfixed HIGH CVEs in base
+      # Rationale: nginx:1.29-alpine ships with unfixed HIGH CVEs in base
       # Alpine packages that have no upstream fix yet. Blocking on HIGH would
       # permanently halt the pipeline for issues outside our control. CRITICAL
       # CVEs represent a meaningfully higher risk bar and are always blocked.
       # HIGH findings remain fully visible in the repo's Security tab.
-      - name: Block on CRITICAL vulnerabilities (amd64)
+      - name: Block on CRITICAL vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          image-ref: ghcr.io/budget-buddy-org/budget-buddy-web-app:scan
+          image-ref: ${{ env.IMAGE }}@${{ steps.digest.outputs.sha }}
           format: table
           exit-code: '1'
           severity: CRITICAL
           ignore-unfixed: true
 
-      # Build the final multi-platform image and push it. SBOM and provenance
-      # attestations are attached automatically by build-push-action.
-      - name: Build and push multi-platform image
-        id: build-push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+  # ───────────────────────────────────────────────────────────────────────────
+  # Merge per-platform digests into a multi-arch manifest list, tag it, and
+  # sign the final digest with Cosign (keyless via GitHub OIDC).
+  # ───────────────────────────────────────────────────────────────────────────
+  merge:
+    needs: [build, scan]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: VITE_API_URL=${{ vars.VITE_API_URL }}
-          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
-          sbom: true
-          provenance: mode=max
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
-      # Scan the arm64 image by digest from the registry to catch arch-specific
-      # vulnerabilities in base image packages that may differ from amd64.
-      # Intentionally non-blocking (continue-on-error: true, no exit-code) —
-      # findings are surfaced in the Security tab for visibility without gating
-      # releases on arch-specific vulns that may not be fixable upstream.
-      - name: Scan image with Trivy (arm64)
-        id: trivy-arm64
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        continue-on-error: true
-        with:
-          image-ref: ghcr.io/budget-buddy-org/budget-buddy-web-app@${{ steps.build-push.outputs.digest }}
-          format: sarif
-          output: trivy-arm64.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-        env:
-          TRIVY_PLATFORM: linux/arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
-      - name: Upload arm64 scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-        # Guard on the scan step's own outcome rather than build-push so this
-        # remains correct if the arm64 scan is ever decoupled from build-push.
-        if: always() && steps.trivy-arm64.outcome != 'skipped'
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
-          sarif_file: trivy-arm64.sarif
-          category: trivy-arm64
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Create multi-arch manifest and push
+        id: manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+          # Capture the manifest list digest for signing
+          tag=$(jq -cr '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       # Install Cosign for keyless image signing (GitHub OIDC — no long-lived key).
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
-      # Sign the published image digest with Cosign. Uses GitHub's OIDC token
+      # Sign the published manifest digest with Cosign. Uses GitHub's OIDC token
       # so no signing key needs to be stored or rotated.
       - name: Sign image with Cosign (keyless)
         run: |
           cosign sign --yes \
-            ghcr.io/budget-buddy-org/budget-buddy-web-app@${{ steps.build-push.outputs.digest }}
+            ${{ env.IMAGE }}@${{ steps.manifest.outputs.digest }}


### PR DESCRIPTION
## Why

The publish workflow takes 6-7 minutes per release, with ~3 minutes spent on QEMU-emulated arm64 cross-compilation running sequentially after the amd64 build and scan.

## What changed

- **Parallel native builds**: Replaced the single-job QEMU approach with a matrix strategy — amd64 builds on `ubuntu-latest` and arm64 builds on `ubuntu-24.04-arm` natively, running in parallel. Each pushes a single-platform image by digest.
- **Parallel scan**: Trivy scans the amd64 image in a separate job that runs concurrently with the arm64 build, instead of blocking the entire pipeline.
- **Manifest merge job**: A new `merge` job downloads both digests, creates a multi-arch manifest list with `docker buildx imagetools create`, and signs it with Cosign.
- **Removed QEMU setup**: No longer needed since both platforms build natively.
- **Removed unused `VITE_API_URL` build-arg**: The Dockerfile uses runtime config injection via `envsubst`, not build-time args.
- **Removed arm64 Trivy scan**: Same `nginx:1.29-alpine` base + identical static assets. Alpine tracks CVEs uniformly across architectures. The scan was already non-blocking (`continue-on-error: true`).
- **Scoped GHA caches**: Each platform has its own cache scope (`buildx-amd64`, `buildx-arm64`) to avoid collisions.

## How to verify

1. Trigger the workflow manually via `workflow_dispatch` on this branch
2. Confirm the `build` job spawns two parallel runners (amd64 + arm64)
3. Confirm `scan` job runs Trivy and uploads SARIF to the Security tab
4. Confirm `merge` job creates a multi-arch manifest with both platforms: `docker buildx imagetools inspect ghcr.io/budget-buddy-org/budget-buddy-web-app:latest`
5. Confirm Cosign signature is attached to the manifest digest
6. Compare total runtime — expect ~2-3 min vs previous 6-7 min

## Notes

- `ubuntu-24.04-arm` is a GitHub-hosted runner available on all plans. If it's not enabled for this org, the arm64 job will queue indefinitely — check Settings > Actions > Runner groups.
- SBOM and provenance attestations are attached per-platform in the build job (same as before).