### PR TITLE
fix(security): use single-line CSP header to prevent 502 from proxy

### DIFF
--- a/nginx.security-headers.conf.template
+++ b/nginx.security-headers.conf.template
@@ -15,15 +15,4 @@ add_header Permissions-Policy     "camera=(), microphone=(), geolocation=()"    
 # - connect-src includes the API and OIDC issuer for token/userinfo endpoints.
 # - frame-src includes the OIDC issuer for the silent-renew hidden iframe.
 # - frame-ancestors 'none': blocks all framing (replaces X-Frame-Options).
-add_header Content-Security-Policy "
-  default-src 'self';
-  script-src 'self' 'unsafe-inline';
-  style-src 'self' 'unsafe-inline';
-  img-src 'self' data:;
-  font-src 'self';
-  connect-src 'self' $VITE_API_URL $VITE_OIDC_ISSUER;
-  frame-src $VITE_OIDC_ISSUER;
-  base-uri 'self';
-  form-action 'self';
-  frame-ancestors 'none';
-" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' $VITE_API_URL $VITE_OIDC_ISSUER; frame-src $VITE_OIDC_ISSUER; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;


### PR DESCRIPTION
nginx add_header sends the value verbatim — a multi-line quoted string produces a response header with embedded newlines (\x20 at the start of each continuation line). RFC 7230 forbids newlines in header values, so the nginx reverse proxy correctly rejected every webapp response with 'upstream sent invalid header: \x20...' → 502 Bad Gateway.

Collapse the Content-Security-Policy value to a single line. Semantically identical; no directives changed.