### PR TITLE
fix(security): replace script-src unsafe-inline with SHA-256 hash

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -9,6 +9,9 @@ envsubst '$VITE_API_URL $VITE_OIDC_ISSUER $VITE_OIDC_CLIENT_ID $VITE_OIDC_SCOPES
   > /usr/share/nginx/html/config.json
 
 # Build the Content-Security-Policy header with runtime-resolved OIDC issuer.
+# NOTE: the script-src SHA-256 hash in security-headers.conf.template is tied to the
+# exact content of the inline theme-init script in index.html. If that script changes,
+# the hash must be regenerated — see the comment in nginx.security-headers.conf.template.
 envsubst '$VITE_API_URL $VITE_OIDC_ISSUER' \
   < /etc/nginx/snippets/security-headers.conf.template \
   > /etc/nginx/snippets/security-headers.conf

--- a/nginx.security-headers.conf.template
+++ b/nginx.security-headers.conf.template
@@ -10,9 +10,10 @@ add_header Referrer-Policy        "strict-origin-when-cross-origin"             
 add_header Permissions-Policy     "camera=(), microphone=(), geolocation=()"          always;
 
 # Content Security Policy
-# - script-src 'unsafe-inline': required for the inline theme-init script in
-#   index.html. Replace with a SHA-256 hash if the script is ever extracted.
+# - script-src uses a SHA-256 hash of the inline theme-init script in index.html.
+#   IMPORTANT: regenerate the hash if that script ever changes:
+#   python3 -c "import hashlib,base64; f=open('index.html'); c=f.read(); s=c[c.index('<script>\n')+9:c.index('\n    </script>')]; print(base64.b64encode(hashlib.sha256(s.encode()).digest()).decode())"
+# - style-src 'unsafe-inline' is required for Tailwind v4 runtime styles (accepted trade-off).
 # - connect-src includes the API and OIDC issuer for token/userinfo endpoints.
-# - frame-src includes the OIDC issuer for the silent-renew hidden iframe.
 # - frame-ancestors 'none': blocks all framing (replaces X-Frame-Options).
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' $VITE_API_URL $VITE_OIDC_ISSUER; frame-src $VITE_OIDC_ISSUER; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-BU3i5kJoqq+zoV0GtVJMrCHToZIxLjoYdRDeSeydpk4='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' $VITE_API_URL $VITE_OIDC_ISSUER; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" always;


### PR DESCRIPTION
## Summary

- **#94** — Replace `script-src 'self' 'unsafe-inline'` with `script-src 'self' 'sha256-BU3i5kJoqq+zoV0GtVJMrCHToZIxLjoYdRDeSeydpk4='` in `nginx.security-headers.conf.template`. The hash covers the exact bytes of the inline theme-init script in `index.html` (lines 18–35).

  Also removes `frame-src $VITE_OIDC_ISSUER` — it was only needed for the hidden-iframe silent renew, which is removed in #104.

- `docker-entrypoint.sh` updated with a warning comment: the hash is load-bearing and must be regenerated if the inline script in `index.html` changes. The comment includes the one-liner to regenerate it.

- `style-src 'unsafe-inline'` is intentionally left in place — required for Tailwind v4 runtime style injection.

## Hash generation

```bash
python3 -c "
import hashlib, base64
f = open('index.html'); c = f.read()
s = c[c.index('<script>\n')+9 : c.index('\n    </script>')]
print(base64.b64encode(hashlib.sha256(s.encode()).digest()).decode())
"
# BU3i5kJoqq+zoV0GtVJMrCHToZIxLjoYdRDeSeydpk4=
```

## Test plan

- [ ] Deploy the container locally → browser loads the app without CSP violations in DevTools Console
- [ ] Intentionally break the hash → browser blocks the inline script, app loads without theme (expected)
- [ ] Verify no `frame-src` in the served `Content-Security-Policy` header
- [ ] Depends on #104 being merged first (removes `silent-renew.html` and the iframe approach)

Closes #94