### PR TITLE
chore: remove Zitadel-specific branding from docs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,6 +1,6 @@
 # Authentication Architecture
 
-Budget Buddy uses **OpenID Connect (OIDC)** with [Zitadel](https://zitadel.com) as the identity provider. All authentication is handled by the IdP — the frontend never manages credentials or issues tokens.
+Budget Buddy uses **OpenID Connect (OIDC)** with an external identity provider. All authentication is handled by the IdP — the frontend never manages credentials or issues tokens.
 
 ## Flow
 
@@ -22,7 +22,7 @@ Tokens are stored in **`sessionStorage`** by `oidc-client-ts` (the library defau
 
 ## Background Token Renewal
 
-`automaticSilentRenew: true` instructs `oidc-client-ts` to refresh tokens in the background before they expire. The library creates a hidden iframe pointing to the IdP's authorization endpoint and redirects to `/silent-renew.html`. That page posts the response URL back to the parent frame via `postMessage` — the React bundle is never loaded in the iframe.
+`automaticSilentRenew: true` instructs `oidc-client-ts` to refresh tokens in the background before they expire. When a `refresh_token` is present (granted by the `offline_access` scope), `oidc-client-ts` v3 uses the **refresh token grant** — no hidden iframe or third-party cookies required.
 
 In addition, `getAuthToken()` in `src/lib/api.ts` performs a **proactive refresh** via `signinSilent()` if the token expires within 60 seconds. This prevents mid-request token expiry in the window between `automaticSilentRenew` cycles.
 
@@ -37,8 +37,8 @@ All three settings are injected at container startup via `envsubst` — **no ima
 | Variable | Purpose |
 |---|---|
 | `VITE_API_URL` | Backend API base URL |
-| `VITE_OIDC_ISSUER` | OIDC issuer URL (e.g. `https://your-tenant.zitadel.cloud`) |
-| `VITE_OIDC_CLIENT_ID` | SPA client ID registered in Zitadel |
+| `VITE_OIDC_ISSUER` | OIDC issuer URL (the base URL of your identity provider) |
+| `VITE_OIDC_CLIENT_ID` | SPA client ID registered at your identity provider |
 
 In Docker, the entrypoint substitutes these into `config.json` (served at `/config.json`) and into the nginx Content-Security-Policy header. `src/lib/config.ts` reads `config.json` at startup before the app renders.
 
@@ -46,19 +46,18 @@ For local development, set these in `.env.local`:
 
 ```
 VITE_API_URL=http://localhost:8080
-VITE_OIDC_ISSUER=https://your-tenant.zitadel.cloud
+VITE_OIDC_ISSUER=https://your-idp.example.com
 VITE_OIDC_CLIENT_ID=your-client-id
 ```
 
-## Zitadel Client Setup
+## IdP Client Setup
 
-Register a **SPA** application in Zitadel with:
+Register a **SPA / public client** application at your identity provider with:
 
 - **Grant type:** Authorization Code
 - **Auth method:** None (PKCE only — no client secret)
 - **Redirect URI:** `https://your-app.example.com/auth/callback`
 - **Post-logout redirect URI:** `https://your-app.example.com/`
-- **Silent renew URI:** `https://your-app.example.com/silent-renew.html`
 - **Scopes:** `openid profile email offline_access`
 
 ## Content Security Policy
@@ -67,12 +66,12 @@ The nginx security headers include a `Content-Security-Policy` built from the ru
 
 ```
 connect-src 'self' <VITE_API_URL> <VITE_OIDC_ISSUER>
-frame-src <VITE_OIDC_ISSUER>
+script-src 'self' 'sha256-BU3i5kJoqq+zoV0GtVJMrCHToZIxLjoYdRDeSeydpk4='
 ```
 
-This prevents credentials from being exfiltrated to unexpected origins even if an XSS vulnerability is present. The `frame-src` directive is required for the silent-renew iframe.
+This prevents credentials from being exfiltrated to unexpected origins even if an XSS vulnerability is present. The `script-src` directive uses a SHA-256 hash of the theme-init inline script in `index.html` — no `unsafe-inline` needed.
 
-> **Note:** `script-src` currently includes `'unsafe-inline'` to support the theme-initialisation inline script in `index.html`. Replace it with a SHA-256 hash once that script is stable.
+> **Note:** if the inline script in `index.html` is ever modified, regenerate the hash (see the comment in `nginx.security-headers.conf.template`).
 
 ## Key Files
 
@@ -83,6 +82,5 @@ This prevents credentials from being exfiltrated to unexpected origins even if a
 | `src/lib/config.ts` | Runtime config loader (reads `/config.json`) |
 | `src/components/layout/ProtectedAppLayout.tsx` | Auth guard for all `_app/` routes |
 | `src/routes/auth/callback.tsx` | OIDC callback landing page |
-| `public/silent-renew.html` | Minimal page for background token renewal |
 | `nginx.security-headers.conf.template` | CSP + security headers template |
 | `docker/docker-entrypoint.sh` | `envsubst` injection at container startup |


### PR DESCRIPTION
## Summary

Updates `docs/auth.md` to be provider-agnostic:

- First line: "external identity provider" instead of Zitadel
- Background Token Renewal section updated to reflect the refresh token grant (no iframe)
- Runtime config examples use `your-idp.example.com` instead of `your-tenant.zitadel.cloud`
- IdP Client Setup section renamed and "Silent renew URI" removed (no longer needed)
- CSP section updated to reference the SHA-256 hash approach
- Key Files table: removed the deleted `silent-renew.html` entry

Note: `LoginPage.tsx` and `RegisterPage.tsx` (which had "Sign in with Zitadel" strings) were already deleted in the OIDC migration — #97 is effectively resolved for those files.

Closes #97