### PR TITLE
feat(security): DPoP sender-constrained tokens + fix session-persistence bugs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -10,7 +10,7 @@ User visits /                   ProtectedAppLayout checks auth state
   → browser redirects to IdP    Authorization Code Flow + PKCE
   → user authenticates
   → IdP redirects to /auth/callback   AuthCallbackPage shown briefly
-  → react-oidc-context exchanges code  tokens stored in sessionStorage
+  → react-oidc-context exchanges code  tokens stored in localStorage
   → onOidcSigninCallback() clears URL  app renders normally
 ```
 
@@ -18,13 +18,57 @@ User visits /                   ProtectedAppLayout checks auth state
 
 ## Token Storage
 
-Tokens are stored in **`sessionStorage`** by `oidc-client-ts` (the library default). `sessionStorage` is tab-scoped and cleared when the tab is closed, limiting the blast radius of XSS compared to `localStorage`. A Backend-for-Frontend (BFF) with HttpOnly cookies would further reduce exposure but requires server infrastructure.
+The signed-in user (access token + refresh token) is stored in **`localStorage`** via an explicit `userStore: new WebStorageStateStore({ store: localStorage })` in `src/lib/oidc.ts`. `localStorage` persists across tab close and browser restart — without this override `oidc-client-ts` defaults to `sessionStorage`, which wipes the session every time the last tab closes and forces a full round-trip to the IdP on next visit.
+
+Short-lived PKCE state (`state`, `code_verifier`) is kept in `sessionStorage` (`stateStore`). It only needs to survive the redirect round-trip, so the tighter scope is appropriate.
+
+The XSS blast-radius tradeoff is mitigated by two layers:
+
+1. The strict CSP (see below) — any script not in `script-src` cannot read `localStorage` because it will not execute.
+2. **DPoP sender-constrained tokens** (see next section) — even if an access or refresh token is exfiltrated via XSS, it is cryptographically bound to a non-extractable `CryptoKey` held in this browser's IndexedDB, so an attacker cannot replay it from another origin or device.
+
+## DPoP — Sender-constrained tokens (RFC 9449)
+
+The app enables **DPoP** (*Demonstration of Proof-of-Possession*) in `src/lib/oidc.ts`:
+
+```ts
+dpop: {
+  bind_authorization_code: true,
+  store: new IndexedDbDPoPStore(),
+}
+```
+
+- On first sign-in, `oidc-client-ts` generates a non-extractable `CryptoKeyPair` using WebCrypto and stores it in IndexedDB via `IndexedDbDPoPStore`. The private key cannot be exported by any JavaScript.
+- Every token-endpoint call (auth-code exchange, silent renew) includes a DPoP proof JWT that proves possession of the private key. The IdP (Zitadel) embeds the public key's JWK thumbprint in the access token's `cnf.jkt` claim.
+- Because `bind_authorization_code: true` is set, the auth code itself is bound to the key — a leaked redirect (e.g. via logging or browser history) cannot be exchanged for tokens by an attacker without the key.
+- `user.token_type` is set to `"DPoP"` after a successful exchange.
+
+### Per-request proofs
+
+For every outgoing API call, the request interceptor in `src/lib/api.ts`:
+
+1. Reads `user.token_type` and uses it as the `Authorization` scheme (`DPoP <access_token>` instead of `Bearer <access_token>`).
+2. Calls `getUserManager().dpopProof(url, user, method)` to generate a short-lived proof JWT bound to the specific URL and HTTP method.
+3. Attaches the proof on the `DPoP` header.
+
+The resource server (Spring Security 7) auto-detects the `DPoP` scheme via `DPoPAuthenticationConfigurer` and validates the proof's signature, `htm`/`htu` (method/URL), `ath` (access-token hash), and `jti` (replay cache) claims.
+
+### Key lifecycle
+
+- The keypair lives in IndexedDB (`oidc` database, default store) keyed by `client_id`.
+- It is reused across all tabs/windows of this browser profile.
+- It is **not** automatically deleted on `signoutRedirect()`; if you need to rotate the key, clear the `oidc` IndexedDB database explicitly. Rotation typically happens naturally when the user clears site data.
+- iOS / Telegram / other non-browser clients should not enable DPoP unless they have a hardware-backed key store (Keychain / Secure Enclave). Plain Bearer tokens are acceptable there.
 
 ## Background Token Renewal
 
-`automaticSilentRenew: true` instructs `oidc-client-ts` to refresh tokens in the background before they expire. The library creates a hidden iframe pointing to the IdP's authorization endpoint and redirects to the configured silent redirect URI. The app uses `/auth/silent-renew` as the silent redirect callback; configure your IdP's silent redirect URI accordingly (see IdP setup below). The callback returns the response to the parent frame via `postMessage` so the React bundle is not loaded in the iframe.
+`automaticSilentRenew: true` instructs `oidc-client-ts` to refresh tokens in the background before they expire. When a refresh token is present (from `offline_access` scope), the SDK uses it directly; otherwise it falls back to a hidden iframe pointing at the IdP's authorization endpoint. The iframe is redirected to `/auth/silent-renew.html`, which posts the resulting URL back to the parent window via `postMessage` so the React bundle is not re-loaded inside the iframe. Configure the matching silent redirect URI in your IdP (see IdP setup below).
 
-In addition, `getAuthToken()` in `src/lib/api.ts` performs a **proactive refresh** via `signinSilent()` if the token expires within 60 seconds. This prevents mid-request token expiry in the window between `automaticSilentRenew` cycles.
+### Safety-net refresh
+
+`getAuthToken()` in `src/lib/api.ts` performs a **safety-net refresh** via `signinSilent()` only when the token is within **10 seconds** of expiry. The threshold is deliberately well below the SDK's 60-second `automaticSilentRenew` trigger so the two paths don't race — overlapping refreshes both redeem the same refresh token, which providers with rotation enabled (Zitadel by default) treat as theft and invalidate.
+
+Concurrent calls to `getAuthToken()` are **deduped** onto a single in-flight `signinSilent()` promise (`pendingSilentRenew`). Without dedupe, a burst of API requests firing simultaneously would each trigger their own refresh and invalidate the session.
 
 ## Session Expiry
 
@@ -61,8 +105,17 @@ Register a **SPA** application in your IdP with:
 - **Auth method:** None (PKCE only — no client secret)
 - **Redirect URI:** `https://your-app.example.com/auth/callback`
 - **Post-logout redirect URI:** `https://your-app.example.com/`
-- **Silent renew URI:** `https://your-app.example.com/auth/silent-renew`
-- **Scopes:** `openid profile email offline_access`
+- **Silent renew URI:** `https://your-app.example.com/auth/silent-renew.html`
+- **Scopes:** `openid profile email offline_access` — `offline_access` is **required** to receive a refresh token. Without it, the session ends when the short-lived access token expires (~1 hour on most providers).
+
+### Zitadel-specific settings
+
+If the user is being logged out more often than expected, check these in the Zitadel console under the SPA app's settings:
+
+1. **Refresh Token**: enable it on the application. Without the toggle, Zitadel will not issue a refresh token even when `offline_access` is in the scope.
+2. **Token Lifetime & Expiration** (under the project settings): increase **Refresh Token Idle Expiration** (default: 24h) and **Refresh Token Expiration** (default: 30d) to match how long you want sessions to stay alive across idle periods.
+3. **Access Token Type**: must be `JWT` so the API can validate locally.
+4. **Proof of Possession (DPoP)**: enable *Require Proof of Possession (DPoP)* (or equivalent setting) on the SPA app so Zitadel issues DPoP-bound tokens. The app always sends a DPoP proof on the token endpoint; Zitadel must honor it for the `cnf.jkt` binding to land in access tokens.
 
 ## Content Security Policy
 
@@ -86,6 +139,6 @@ This prevents credentials from being exfiltrated to unexpected origins even if a
 | `src/lib/config.ts` | Runtime config loader (reads `/config.json`) |
 | `src/components/layout/ProtectedAppLayout.tsx` | Auth guard for all `_app/` routes |
 | `src/routes/auth/callback.tsx` | OIDC callback landing page |
-| `src/routes/auth/silent-renew` | Silent renew callback route used by the OIDC SDK |
+| `public/auth/silent-renew.html` | Static page loaded in the silent-renew iframe; posts the response URL back to the parent window |
 | `nginx.security-headers.conf.template` | CSP + security headers template |
 | `docker/docker-entrypoint.sh` | `envsubst` injection at container startup |

--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -35,12 +35,11 @@ export function DashboardPage() {
   const [showAll, setShowAll] = useState(false);
   const glassEffect = useThemeStore((s) => s.glassEffect);
 
-  // Computed on initial mount so the dashboard never shows stale dates if the app
-  // stays open overnight and the user navigates back after midnight.
-  const [{ currentYear, currentMonth }] = useState(() => {
-    const now = new Date();
-    return { currentYear: now.getFullYear(), currentMonth: now.getMonth() };
-  });
+  // Recomputed every render so the dashboard rolls over correctly when the app
+  // stays open past midnight (especially across a month boundary).
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth();
 
   const [selectedMonth, setSelectedMonth] = useState(currentMonth);
 

--- a/src/components/transactions/TransactionForm.test.tsx
+++ b/src/components/transactions/TransactionForm.test.tsx
@@ -19,7 +19,13 @@ vi.mock('@/hooks/useTransactions', () => ({
   useDeleteTransaction: () => mockDeleteTx,
 }));
 
-const mockCreateCategory = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false, error: null };
+const mockCreateCategory = {
+  mutate: vi.fn(),
+  mutateAsync: vi.fn(),
+  reset: vi.fn(),
+  isPending: false,
+  error: null,
+};
 vi.mock('@/hooks/useCategories', () => ({
   useCreateCategory: () => mockCreateCategory,
 }));

--- a/src/components/transactions/TransactionForm.tsx
+++ b/src/components/transactions/TransactionForm.tsx
@@ -83,6 +83,12 @@ export function TransactionForm({
       try {
         const newCat = await createCategory.mutateAsync({ name: newCategoryName });
         categoryId = newCat.id;
+        // Commit the new category to the form so that if the transaction
+        // mutation below fails, retrying won't re-run createCategory (which
+        // would either duplicate or error with "already exists").
+        setForm((f) => ({ ...f, categoryId: newCat.id }));
+        setIsAddingCategory(false);
+        setNewCategoryName('');
       } catch (error) {
         const apiError = getApiError(error);
         toast({
@@ -274,7 +280,11 @@ export function TransactionForm({
                 variant="ghost"
                 size="sm"
                 className="h-6 px-2 text-xs font-medium"
-                onClick={() => setIsAddingCategory((v) => !v)}
+                onClick={() => {
+                  setIsAddingCategory((v) => !v);
+                  setNewCategoryName('');
+                  createCategory.reset();
+                }}
                 disabled={isPending}
               >
                 {isAddingCategory ? (

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -39,6 +39,7 @@ const MAX_PAGES_ALL = 10;
 
 const KEYS = {
   all: ['transactions'] as const,
+  lists: ['transactions', 'list'] as const,
   list: (filters: TransactionFilters) => ['transactions', 'list', filters] as const,
   infinite: (filters: TransactionFilters) => ['transactions', 'infinite', filters] as const,
   detail: (id: string) => ['transactions', id] as const,
@@ -192,12 +193,20 @@ export function useDeleteTransaction() {
     },
     onMutate: async (id) => {
       await qc.cancelQueries({ queryKey: KEYS.all });
-      const previous = qc.getQueriesData<PaginatedTransactions>({ queryKey: KEYS.all });
+      const previous = qc.getQueriesData<PaginatedTransactions>({ queryKey: KEYS.lists });
 
-      // Optimistically update all paginated lists
-      qc.setQueriesData<PaginatedTransactions>({ queryKey: ['transactions', 'list'] }, (old) =>
-        old ? { ...old, items: old.items.filter((t) => t.id !== id) } : old,
-      );
+      // Optimistically update every cached list view — removing the tx by id
+      // is safe regardless of the filters each list was fetched with.
+      qc.setQueriesData<PaginatedTransactions>({ queryKey: KEYS.lists }, (old) => {
+        if (!old) return old;
+        const nextItems = old.items.filter((t) => t.id !== id);
+        if (nextItems.length === old.items.length) return old;
+        return {
+          ...old,
+          items: nextItems,
+          meta: { ...old.meta, total: Math.max(0, old.meta.total - 1) },
+        };
+      });
 
       return { previous };
     },

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -4,6 +4,7 @@ const mockUserManager = {
   getUser: vi.fn(),
   signinSilent: vi.fn(),
   signinRedirect: vi.fn(),
+  dpopProof: vi.fn(),
 };
 
 vi.mock('@/lib/oidc', () => ({
@@ -60,10 +61,24 @@ describe('getAuthToken', () => {
     expect(mockUserManager.signinSilent).not.toHaveBeenCalled();
   });
 
-  it('proactively refreshes when the token expires within 60 seconds', async () => {
+  it('does not refresh when the token is more than 10 seconds from expiry', async () => {
+    // Trust the SDK's automaticSilentRenew (which fires at ~60s before expiry)
+    // for anything above the safety-net threshold.
+    mockUserManager.getUser.mockResolvedValue({
+      access_token: 'still-fresh',
+      expires_at: Date.now() / 1000 + 30,
+    });
+
+    const token = await getAuthToken();
+
+    expect(mockUserManager.signinSilent).not.toHaveBeenCalled();
+    expect(token).toBe('still-fresh');
+  });
+
+  it('proactively refreshes when the token expires within 10 seconds', async () => {
     mockUserManager.getUser.mockResolvedValue({
       access_token: 'old-token',
-      expires_at: Date.now() / 1000 + 30, // 30s remaining — under the 60s threshold
+      expires_at: Date.now() / 1000 + 5, // 5s remaining — under the 10s safety-net threshold
     });
     mockUserManager.signinSilent.mockResolvedValue({ access_token: 'new-token' });
 
@@ -71,6 +86,21 @@ describe('getAuthToken', () => {
 
     expect(mockUserManager.signinSilent).toHaveBeenCalled();
     expect(token).toBe('new-token');
+  });
+
+  it('dedupes concurrent refresh calls onto a single signinSilent invocation', async () => {
+    mockUserManager.getUser.mockResolvedValue({
+      access_token: 'old-token',
+      expires_at: Date.now() / 1000 + 5,
+    });
+    mockUserManager.signinSilent.mockResolvedValue({ access_token: 'new-token' });
+
+    const [t1, t2, t3] = await Promise.all([getAuthToken(), getAuthToken(), getAuthToken()]);
+
+    expect(mockUserManager.signinSilent).toHaveBeenCalledTimes(1);
+    expect(t1).toBe('new-token');
+    expect(t2).toBe('new-token');
+    expect(t3).toBe('new-token');
   });
 
   it('returns undefined when no user is logged in', async () => {
@@ -85,7 +115,7 @@ describe('getAuthToken', () => {
   it('returns undefined when silent refresh fails', async () => {
     mockUserManager.getUser.mockResolvedValue({
       access_token: 'old-token',
-      expires_at: Date.now() / 1000 + 10,
+      expires_at: Date.now() / 1000 + 5,
     });
     mockUserManager.signinSilent.mockRejectedValue(new Error('network error'));
 
@@ -100,7 +130,22 @@ describe('request interceptor', () => {
     vi.clearAllMocks();
   });
 
-  it('sets Authorization header when a token is available', async () => {
+  it('sets a Bearer Authorization header when token_type is Bearer', async () => {
+    mockUserManager.getUser.mockResolvedValue({
+      access_token: 'test-token',
+      token_type: 'Bearer',
+      expires_at: Date.now() / 1000 + 3600,
+    });
+
+    const req = makeRequest();
+    const result = await requestInterceptor?.(req);
+
+    expect(result?.headers.get('Authorization')).toBe('Bearer test-token');
+    expect(result?.headers.get('DPoP')).toBeNull();
+    expect(mockUserManager.dpopProof).not.toHaveBeenCalled();
+  });
+
+  it('defaults to Bearer when token_type is missing', async () => {
     mockUserManager.getUser.mockResolvedValue({
       access_token: 'test-token',
       expires_at: Date.now() / 1000 + 3600,
@@ -110,6 +155,28 @@ describe('request interceptor', () => {
     const result = await requestInterceptor?.(req);
 
     expect(result?.headers.get('Authorization')).toBe('Bearer test-token');
+    expect(result?.headers.get('DPoP')).toBeNull();
+  });
+
+  it('sets DPoP Authorization scheme and attaches a proof when token_type is DPoP', async () => {
+    const user = {
+      access_token: 'dpop-token',
+      token_type: 'DPoP',
+      expires_at: Date.now() / 1000 + 3600,
+    };
+    mockUserManager.getUser.mockResolvedValue(user);
+    mockUserManager.dpopProof.mockResolvedValue('proof-jwt');
+
+    const req = makeRequest('http://localhost/v1/transactions');
+    const result = await requestInterceptor?.(req);
+
+    expect(result?.headers.get('Authorization')).toBe('DPoP dpop-token');
+    expect(result?.headers.get('DPoP')).toBe('proof-jwt');
+    expect(mockUserManager.dpopProof).toHaveBeenCalledWith(
+      'http://localhost/v1/transactions',
+      user,
+      'GET',
+    );
   });
 
   it('does not set Authorization header when user is not logged in', async () => {
@@ -119,6 +186,22 @@ describe('request interceptor', () => {
     const result = await requestInterceptor?.(req);
 
     expect(result?.headers.get('Authorization')).toBeNull();
+    expect(result?.headers.get('DPoP')).toBeNull();
+  });
+
+  it('omits the DPoP header when dpopProof returns undefined (DPoP disabled client-side)', async () => {
+    mockUserManager.getUser.mockResolvedValue({
+      access_token: 'dpop-token',
+      token_type: 'DPoP',
+      expires_at: Date.now() / 1000 + 3600,
+    });
+    mockUserManager.dpopProof.mockResolvedValue(undefined);
+
+    const req = makeRequest();
+    const result = await requestInterceptor?.(req);
+
+    expect(result?.headers.get('Authorization')).toBe('DPoP dpop-token');
+    expect(result?.headers.get('DPoP')).toBeNull();
   });
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,34 +1,71 @@
 import { client } from '@budget-buddy-org/budget-buddy-contracts/client.gen';
+import type { User } from 'oidc-client-ts';
 import { getUserManager } from '@/lib/oidc';
 
-const REFRESH_THRESHOLD_SECONDS = 60;
+// Only proactively refresh when the token is basically gone. The SDK's
+// automaticSilentRenew already fires 60s before expiry; overlapping with it
+// causes duplicate refresh-token redemptions which Zitadel (with rotation on)
+// treats as theft and invalidates the session. This safety net only kicks in
+// when the SDK's setTimeout was throttled/killed in a backgrounded tab.
+const REFRESH_THRESHOLD_SECONDS = 10;
+
+// Dedupe concurrent refreshes. Multiple in-flight API requests must share a
+// single signinSilent() call; otherwise we redeem the same refresh token N
+// times in parallel and get rotated out.
+let pendingSilentRenew: Promise<User | null> | null = null;
+
+function refreshSilently(): Promise<User | null> {
+  pendingSilentRenew ??= getUserManager()
+    .signinSilent()
+    .catch(() => null)
+    .finally(() => {
+      pendingSilentRenew = null;
+    });
+  return pendingSilentRenew;
+}
 
 /**
- * Returns a fresh access token for the current user.
- * Proactively triggers a silent refresh if the token expires within 60 seconds,
- * preventing mid-request expiry between automaticSilentRenew cycles.
+ * Returns a fresh signed-in User for the current session.
+ * Proactively triggers a silent refresh only when the token is within
+ * REFRESH_THRESHOLD_SECONDS of expiry (safety net for throttled background tabs).
  */
-export async function getAuthToken(): Promise<string | undefined> {
+export async function getAuthUser(): Promise<User | null> {
   const user = await getUserManager().getUser();
-  if (!user) return undefined;
+  if (!user) return null;
 
   const now = Date.now() / 1000;
   if (user.expires_at !== undefined && user.expires_at - now < REFRESH_THRESHOLD_SECONDS) {
-    const refreshed = await getUserManager()
-      .signinSilent()
-      .catch(() => null);
-    return refreshed?.access_token ?? undefined;
+    return await refreshSilently();
   }
 
-  return user.access_token ?? undefined;
+  return user;
 }
 
-// Attach a fresh Bearer token to every outgoing request.
+/**
+ * @deprecated Prefer `getAuthUser()`. Kept for call sites that only need the raw token.
+ */
+export async function getAuthToken(): Promise<string | undefined> {
+  return (await getAuthUser())?.access_token ?? undefined;
+}
+
+// Attach the access token to every outgoing request, using `user.token_type`
+// as the auth scheme. When DPoP is enabled on the IdP, `token_type` comes back
+// as "DPoP" and we also attach a freshly signed proof JWT bound to the request
+// URL + method. With plain Bearer tokens the DPoP branch is a no-op.
 client.interceptors.request.use(async (request) => {
-  const token = await getAuthToken();
-  if (token) {
-    request.headers.set('Authorization', `Bearer ${token}`);
+  const user = await getAuthUser();
+  if (!user?.access_token) return request;
+
+  const scheme = user.token_type || 'Bearer';
+  request.headers.set('Authorization', `${scheme} ${user.access_token}`);
+
+  if (scheme.toLowerCase() === 'dpop') {
+    const proof = await getUserManager().dpopProof(request.url, user, request.method);
+    if (proof) {
+      request.headers.set('DPoP', proof);
+    }
   }
+
   return request;
 });
 

--- a/src/lib/oidc.test.ts
+++ b/src/lib/oidc.test.ts
@@ -29,6 +29,20 @@ describe('buildOidcSettings', () => {
 
     expect(settings.stateStore).toBeDefined();
   });
+
+  it('configures a persistent user store so the session survives tab close', () => {
+    const settings = buildOidcSettings('https://issuer.example.com', 'web-client');
+
+    expect(settings.userStore).toBeDefined();
+  });
+
+  it('enables DPoP with authorization-code binding and a persistent DPoP store', () => {
+    const settings = buildOidcSettings('https://issuer.example.com', 'web-client');
+
+    expect(settings.dpop).toBeDefined();
+    expect(settings.dpop?.bind_authorization_code).toBe(true);
+    expect(settings.dpop?.store).toBeDefined();
+  });
 });
 
 describe('getUserManager / initUserManager', () => {

--- a/src/lib/oidc.ts
+++ b/src/lib/oidc.ts
@@ -1,4 +1,9 @@
-import { UserManager, type UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts';
+import {
+  IndexedDbDPoPStore,
+  UserManager,
+  type UserManagerSettings,
+  WebStorageStateStore,
+} from 'oidc-client-ts';
 
 let _userManager: UserManager | null = null;
 
@@ -23,6 +28,21 @@ export function buildOidcSettings(
     filterProtocolClaims: true,
     loadUserInfo: true,
     stateStore: new WebStorageStateStore({ store: globalThis.sessionStorage }),
+    // Persist the signed-in user (access token + refresh token) in localStorage
+    // so the session survives tab close and browser restart. The SDK default is
+    // sessionStorage, which logs the user out on every new tab / cold start.
+    // Exposure is mitigated by binding the token to a non-extractable DPoP key
+    // (see `dpop` below) and the strict CSP enforced by the proxy.
+    userStore: new WebStorageStateStore({ store: globalThis.localStorage }),
+    // DPoP (RFC 9449): issues a non-extractable keypair in IndexedDB and binds
+    // every access/refresh token to it. A token stolen via XSS cannot be used
+    // from another origin/device because the private key never leaves this
+    // browser. `bind_authorization_code` extends the binding to the auth code
+    // so a leaked redirect can't be traded for tokens either.
+    dpop: {
+      bind_authorization_code: true,
+      store: new IndexedDbDPoPStore(),
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- **DPoP (RFC 9449):** enable `dpop: { bind_authorization_code: true, store: new IndexedDbDPoPStore() }` in `src/lib/oidc.ts`. Every access + refresh token is now sender-constrained to a non-extractable `CryptoKey` in IndexedDB. An attacker who exfiltrates a token via XSS cannot replay it from another origin or device. Request interceptor uses `user.token_type` as the auth scheme and attaches a per-request proof via `userManager.dpopProof(url, user, method)`. Bearer path is preserved for non-DPoP clients.
- **Session persistence:** `userStore: localStorage` override — `oidc-client-ts` defaults to `sessionStorage` which wipes tokens on tab close and was the root cause of "frequent logouts". XSS exposure is now mitigated by both the strict CSP and the DPoP binding above.
- **Refresh-race fix:** drop the proactive-refresh threshold from 60s to 10s so the interceptor never overlaps the SDK's own `automaticSilentRenew` (fires at 60s before expiry), and dedupe concurrent refreshes onto a single in-flight promise. Overlapping refreshes both redeem the same refresh token, which Zitadel's rotation treats as theft and invalidates the session.
- **Bug fixes:**
  - Dashboard: recompute `currentYear`/`currentMonth` each render — the old `useState` snapshot went stale across midnight / month boundaries.
  - TransactionForm: after a successful `createCategory`, commit the new id to form state and exit "add new" mode — prevents re-creating the same category on retry when the transaction mutation fails afterwards.
  - TransactionForm: reset `newCategoryName` and `createCategory.reset()` on "add new" ↔ "choose existing" toggle so stale input doesn't linger.
  - useDeleteTransaction: decrement `meta.total` on optimistic removal and use shared `KEYS.lists` prefix.

## Coordinated PRs

- `budget-buddy-api` [#140](https://github.com/budget-buddy-org/budget-buddy-api/pull/140) — `server.forward-headers-strategy: framework`; DPoP auto-wires when the class is on classpath (already is).
- `budget-buddy-deployment` [#6](https://github.com/budget-buddy-org/budget-buddy-deployment/pull/6) — nginx `X-Forwarded-Host`, OIDC_SETUP docs, dropped stale push-deploy flow.
- `budget-buddy-contracts` [#81](https://github.com/budget-buddy-org/budget-buddy-contracts/pull/81) — docs-only note about DPoP alongside Bearer.

## Before deploying

Turn on **Require Proof of Possession (DPoP)** on the Zitadel *Web App* SPA client. Without it, Zitadel keeps issuing plain Bearer tokens and the web app will still work (falls through the Bearer path) but the security benefit is not realized. See deployment PR for full Zitadel checklist.

## Test plan

- [x] `pnpm lint` — no errors
- [x] `pnpm type-check` — no errors
- [x] `pnpm test` — 131 tests passing (5 new for DPoP + dedupe + token-type handling)
- [x] `pnpm build` — clean
- [ ] After the coordinated PRs merge and the Pi redeploy, verify in DevTools that:
  - Every `/v1/*` request has `Authorization: DPoP <jwt>` and a `DPoP: <proof>` header.
  - `Application → Local Storage → oidc.user:...` contains `token_type: "DPoP"` and the access token's `cnf.jkt` claim matches the key in IndexedDB.
  - `Application → IndexedDB → oidc` contains a `CryptoKeyPair` with `privateKey.extractable === false`.
  - Closing the tab and reopening lands on the dashboard without an IdP redirect.
  - Copying `localStorage` into a different browser and trying to call the API returns 401 (stolen token cannot mint proofs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)