### PR TITLE
refactor(security): remove dormant DPoP plumbing — IdP does not support it

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -22,43 +22,7 @@ The signed-in user (access token + refresh token) is stored in **`localStorage`*
 
 Short-lived PKCE state (`state`, `code_verifier`) is kept in `sessionStorage` (`stateStore`). It only needs to survive the redirect round-trip, so the tighter scope is appropriate.
 
-The XSS blast-radius tradeoff is mitigated by two layers:
-
-1. The strict CSP (see below) — any script not in `script-src` cannot read `localStorage` because it will not execute.
-2. **DPoP sender-constrained tokens** (see next section) — even if an access or refresh token is exfiltrated via XSS, it is cryptographically bound to a non-extractable `CryptoKey` held in this browser's IndexedDB, so an attacker cannot replay it from another origin or device.
-
-## DPoP — Sender-constrained tokens (RFC 9449)
-
-The app enables **DPoP** (*Demonstration of Proof-of-Possession*) in `src/lib/oidc.ts`:
-
-```ts
-dpop: {
-  bind_authorization_code: true,
-  store: new IndexedDbDPoPStore(),
-}
-```
-
-- On first sign-in, `oidc-client-ts` generates a non-extractable `CryptoKeyPair` using WebCrypto and stores it in IndexedDB via `IndexedDbDPoPStore`. The private key cannot be exported by any JavaScript.
-- Every token-endpoint call (auth-code exchange, silent renew) includes a DPoP proof JWT that proves possession of the private key. The IdP (Zitadel) embeds the public key's JWK thumbprint in the access token's `cnf.jkt` claim.
-- Because `bind_authorization_code: true` is set, the auth code itself is bound to the key — a leaked redirect (e.g. via logging or browser history) cannot be exchanged for tokens by an attacker without the key.
-- `user.token_type` is set to `"DPoP"` after a successful exchange.
-
-### Per-request proofs
-
-For every outgoing API call, the request interceptor in `src/lib/api.ts`:
-
-1. Reads `user.token_type` and uses it as the `Authorization` scheme (`DPoP <access_token>` instead of `Bearer <access_token>`).
-2. Calls `getUserManager().dpopProof(url, user, method)` to generate a short-lived proof JWT bound to the specific URL and HTTP method.
-3. Attaches the proof on the `DPoP` header.
-
-The resource server (Spring Security 7) auto-detects the `DPoP` scheme via `DPoPAuthenticationConfigurer` and validates the proof's signature, `htm`/`htu` (method/URL), `ath` (access-token hash), and `jti` (replay cache) claims.
-
-### Key lifecycle
-
-- The keypair lives in IndexedDB (`oidc` database, default store) keyed by `client_id`.
-- It is reused across all tabs/windows of this browser profile.
-- It is **not** automatically deleted on `signoutRedirect()`; if you need to rotate the key, clear the `oidc` IndexedDB database explicitly. Rotation typically happens naturally when the user clears site data.
-- iOS / Telegram / other non-browser clients should not enable DPoP unless they have a hardware-backed key store (Keychain / Secure Enclave). Plain Bearer tokens are acceptable there.
+The XSS blast-radius tradeoff is mitigated by the strict CSP (see below) — any script not in `script-src` will not execute and therefore cannot read `localStorage`.
 
 ## Background Token Renewal
 
@@ -66,7 +30,7 @@ The resource server (Spring Security 7) auto-detects the `DPoP` scheme via `DPoP
 
 ### Safety-net refresh
 
-`getAuthToken()` in `src/lib/api.ts` performs a **safety-net refresh** via `signinSilent()` only when the token is within **10 seconds** of expiry. The threshold is deliberately well below the SDK's 60-second `automaticSilentRenew` trigger so the two paths don't race — overlapping refreshes both redeem the same refresh token, which providers with rotation enabled (Zitadel by default) treat as theft and invalidate.
+`getAuthToken()` in `src/lib/api.ts` performs a **safety-net refresh** via `signinSilent()` only when the token is within **10 seconds** of expiry. The threshold is deliberately well below the SDK's 60-second `automaticSilentRenew` trigger so the two paths don't race — overlapping refreshes both redeem the same refresh token, which IdPs that enable refresh-token rotation treat as token theft and invalidate the session.
 
 Concurrent calls to `getAuthToken()` are **deduped** onto a single in-flight `signinSilent()` promise (`pendingSilentRenew`). Without dedupe, a burst of API requests firing simultaneously would each trigger their own refresh and invalidate the session.
 
@@ -108,14 +72,13 @@ Register a **SPA** application in your IdP with:
 - **Silent renew URI:** `https://your-app.example.com/auth/silent-renew.html`
 - **Scopes:** `openid profile email offline_access` — `offline_access` is **required** to receive a refresh token. Without it, the session ends when the short-lived access token expires (~1 hour on most providers).
 
-### Zitadel-specific settings
+### IdP settings to verify if users are logged out more often than expected
 
-If the user is being logged out more often than expected, check these in the Zitadel console under the SPA app's settings:
+Names vary across providers, but most IdPs expose equivalents of the following. Check each in your IdP's admin console under the SPA app's configuration:
 
-1. **Refresh Token**: enable it on the application. Without the toggle, Zitadel will not issue a refresh token even when `offline_access` is in the scope.
-2. **Token Lifetime & Expiration** (under the project settings): increase **Refresh Token Idle Expiration** (default: 24h) and **Refresh Token Expiration** (default: 30d) to match how long you want sessions to stay alive across idle periods.
-3. **Access Token Type**: must be `JWT` so the API can validate locally.
-4. **Proof of Possession (DPoP)**: enable *Require Proof of Possession (DPoP)* (or equivalent setting) on the SPA app so Zitadel issues DPoP-bound tokens. The app always sends a DPoP proof on the token endpoint; Zitadel must honor it for the `cnf.jkt` binding to land in access tokens.
+1. **Refresh Token issuance**: must be enabled on the application. Without it, the IdP will not issue a refresh token even when `offline_access` is requested in the scope, and the session ends as soon as the access token expires.
+2. **Refresh Token idle / absolute expiration**: governs how long a session can stay alive across idle periods and total elapsed time. If users are forced to re-sign-in more often than expected, these are the levers.
+3. **Access Token type / format**: must be **JWT** so the API can validate it locally against the issuer's JWKS without an introspection round-trip.
 
 ## Content Security Policy
 

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -4,7 +4,6 @@ const mockUserManager = {
   getUser: vi.fn(),
   signinSilent: vi.fn(),
   signinRedirect: vi.fn(),
-  dpopProof: vi.fn(),
 };
 
 vi.mock('@/lib/oidc', () => ({
@@ -130,22 +129,7 @@ describe('request interceptor', () => {
     vi.clearAllMocks();
   });
 
-  it('sets a Bearer Authorization header when token_type is Bearer', async () => {
-    mockUserManager.getUser.mockResolvedValue({
-      access_token: 'test-token',
-      token_type: 'Bearer',
-      expires_at: Date.now() / 1000 + 3600,
-    });
-
-    const req = makeRequest();
-    const result = await requestInterceptor?.(req);
-
-    expect(result?.headers.get('Authorization')).toBe('Bearer test-token');
-    expect(result?.headers.get('DPoP')).toBeNull();
-    expect(mockUserManager.dpopProof).not.toHaveBeenCalled();
-  });
-
-  it('defaults to Bearer when token_type is missing', async () => {
+  it('sets Authorization header when a token is available', async () => {
     mockUserManager.getUser.mockResolvedValue({
       access_token: 'test-token',
       expires_at: Date.now() / 1000 + 3600,
@@ -155,28 +139,6 @@ describe('request interceptor', () => {
     const result = await requestInterceptor?.(req);
 
     expect(result?.headers.get('Authorization')).toBe('Bearer test-token');
-    expect(result?.headers.get('DPoP')).toBeNull();
-  });
-
-  it('sets DPoP Authorization scheme and attaches a proof when token_type is DPoP', async () => {
-    const user = {
-      access_token: 'dpop-token',
-      token_type: 'DPoP',
-      expires_at: Date.now() / 1000 + 3600,
-    };
-    mockUserManager.getUser.mockResolvedValue(user);
-    mockUserManager.dpopProof.mockResolvedValue('proof-jwt');
-
-    const req = makeRequest('http://localhost/v1/transactions');
-    const result = await requestInterceptor?.(req);
-
-    expect(result?.headers.get('Authorization')).toBe('DPoP dpop-token');
-    expect(result?.headers.get('DPoP')).toBe('proof-jwt');
-    expect(mockUserManager.dpopProof).toHaveBeenCalledWith(
-      'http://localhost/v1/transactions',
-      user,
-      'GET',
-    );
   });
 
   it('does not set Authorization header when user is not logged in', async () => {
@@ -186,22 +148,6 @@ describe('request interceptor', () => {
     const result = await requestInterceptor?.(req);
 
     expect(result?.headers.get('Authorization')).toBeNull();
-    expect(result?.headers.get('DPoP')).toBeNull();
-  });
-
-  it('omits the DPoP header when dpopProof returns undefined (DPoP disabled client-side)', async () => {
-    mockUserManager.getUser.mockResolvedValue({
-      access_token: 'dpop-token',
-      token_type: 'DPoP',
-      expires_at: Date.now() / 1000 + 3600,
-    });
-    mockUserManager.dpopProof.mockResolvedValue(undefined);
-
-    const req = makeRequest();
-    const result = await requestInterceptor?.(req);
-
-    expect(result?.headers.get('Authorization')).toBe('DPoP dpop-token');
-    expect(result?.headers.get('DPoP')).toBeNull();
   });
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,9 +4,10 @@ import { getUserManager } from '@/lib/oidc';
 
 // Only proactively refresh when the token is basically gone. The SDK's
 // automaticSilentRenew already fires 60s before expiry; overlapping with it
-// causes duplicate refresh-token redemptions which Zitadel (with rotation on)
-// treats as theft and invalidates the session. This safety net only kicks in
-// when the SDK's setTimeout was throttled/killed in a backgrounded tab.
+// causes duplicate refresh-token redemptions, which IdPs that enable
+// refresh-token rotation treat as token theft and invalidate the session.
+// This safety net only kicks in when the SDK's setTimeout was throttled or
+// killed in a backgrounded tab.
 const REFRESH_THRESHOLD_SECONDS = 10;
 
 // Dedupe concurrent refreshes. Multiple in-flight API requests must share a
@@ -25,47 +26,29 @@ function refreshSilently(): Promise<User | null> {
 }
 
 /**
- * Returns a fresh signed-in User for the current session.
+ * Returns a fresh access token for the current user.
  * Proactively triggers a silent refresh only when the token is within
  * REFRESH_THRESHOLD_SECONDS of expiry (safety net for throttled background tabs).
  */
-export async function getAuthUser(): Promise<User | null> {
+export async function getAuthToken(): Promise<string | undefined> {
   const user = await getUserManager().getUser();
-  if (!user) return null;
+  if (!user) return undefined;
 
   const now = Date.now() / 1000;
   if (user.expires_at !== undefined && user.expires_at - now < REFRESH_THRESHOLD_SECONDS) {
-    return await refreshSilently();
+    const refreshed = await refreshSilently();
+    return refreshed?.access_token ?? undefined;
   }
 
-  return user;
+  return user.access_token ?? undefined;
 }
 
-/**
- * @deprecated Prefer `getAuthUser()`. Kept for call sites that only need the raw token.
- */
-export async function getAuthToken(): Promise<string | undefined> {
-  return (await getAuthUser())?.access_token ?? undefined;
-}
-
-// Attach the access token to every outgoing request, using `user.token_type`
-// as the auth scheme. When DPoP is enabled on the IdP, `token_type` comes back
-// as "DPoP" and we also attach a freshly signed proof JWT bound to the request
-// URL + method. With plain Bearer tokens the DPoP branch is a no-op.
+// Attach a fresh Bearer token to every outgoing request.
 client.interceptors.request.use(async (request) => {
-  const user = await getAuthUser();
-  if (!user?.access_token) return request;
-
-  const scheme = user.token_type || 'Bearer';
-  request.headers.set('Authorization', `${scheme} ${user.access_token}`);
-
-  if (scheme.toLowerCase() === 'dpop') {
-    const proof = await getUserManager().dpopProof(request.url, user, request.method);
-    if (proof) {
-      request.headers.set('DPoP', proof);
-    }
+  const token = await getAuthToken();
+  if (token) {
+    request.headers.set('Authorization', `Bearer ${token}`);
   }
-
   return request;
 });
 

--- a/src/lib/oidc.test.ts
+++ b/src/lib/oidc.test.ts
@@ -35,14 +35,6 @@ describe('buildOidcSettings', () => {
 
     expect(settings.userStore).toBeDefined();
   });
-
-  it('enables DPoP with authorization-code binding and a persistent DPoP store', () => {
-    const settings = buildOidcSettings('https://issuer.example.com', 'web-client');
-
-    expect(settings.dpop).toBeDefined();
-    expect(settings.dpop?.bind_authorization_code).toBe(true);
-    expect(settings.dpop?.store).toBeDefined();
-  });
 });
 
 describe('getUserManager / initUserManager', () => {

--- a/src/lib/oidc.ts
+++ b/src/lib/oidc.ts
@@ -1,9 +1,4 @@
-import {
-  IndexedDbDPoPStore,
-  UserManager,
-  type UserManagerSettings,
-  WebStorageStateStore,
-} from 'oidc-client-ts';
+import { UserManager, type UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts';
 
 let _userManager: UserManager | null = null;
 
@@ -31,18 +26,8 @@ export function buildOidcSettings(
     // Persist the signed-in user (access token + refresh token) in localStorage
     // so the session survives tab close and browser restart. The SDK default is
     // sessionStorage, which logs the user out on every new tab / cold start.
-    // Exposure is mitigated by binding the token to a non-extractable DPoP key
-    // (see `dpop` below) and the strict CSP enforced by the proxy.
+    // Exposure to XSS is mitigated by the strict CSP enforced by the proxy.
     userStore: new WebStorageStateStore({ store: globalThis.localStorage }),
-    // DPoP (RFC 9449): issues a non-extractable keypair in IndexedDB and binds
-    // every access/refresh token to it. A token stolen via XSS cannot be used
-    // from another origin/device because the private key never leaves this
-    // browser. `bind_authorization_code` extends the binding to the auth code
-    // so a leaked redirect can't be traded for tokens either.
-    dpop: {
-      bind_authorization_code: true,
-      store: new IndexedDbDPoPStore(),
-    },
   };
 }
 


### PR DESCRIPTION
## Summary

Reverts the DPoP-related code introduced in #113. The OIDC provider currently configured for this deployment does not issue DPoP-bound tokens, so the client-side proof generation, the `token_type`-aware request interceptor, and the documented "DPoP layer" were all no-ops in practice — every request fell through to the Bearer path. Better to delete than to ship dead code that makes a security claim it can't back up.

### Removes

- `IndexedDbDPoPStore` import and the `dpop:` block from `src/lib/oidc.ts`
- `token_type`-aware `Authorization` scheme selection + `dpopProof()` attachment in the `src/lib/api.ts` request interceptor (back to plain `Authorization: Bearer`)
- The deprecated `getAuthUser()` helper introduced as part of DPoP wiring
- DPoP-related test cases in `oidc.test.ts` and `api.test.ts`
- The DPoP section and stale checklist item in `docs/auth.md`

### Keeps (independent of DPoP)

- `userStore: localStorage` override — fixes the original "frequent logouts" symptom
- 10-second safety-net refresh threshold + dedupe in `api.ts` — prevents refresh-token rotation races
- Dashboard / TransactionForm / delete-mutation bug fixes from #113

### If we ever add DPoP back

This is a config-and-doc flip:
- Switch / reconfigure the IdP to issue DPoP-bound tokens.
- Re-add the `dpop:` settings block in `oidc.ts`.
- Re-add the `token_type`-aware interceptor branch in `api.ts`.

The resource server (Spring Security 7 in `budget-buddy-api`) auto-wires the DPoP path when a DPoP-bound token arrives, so no API code change is needed there. The `forward-headers-strategy` and nginx `X-Forwarded-Host` plumbing already in place is correct independent of DPoP.

## Companion PRs

- `budget-buddy-deployment#7` — drops section 3b from `OIDC_SETUP.md`.
- `budget-buddy-contracts#82` — strips DPoP wording from the `BearerAuth` description.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test` — 127 passing (was 131 with the 4 DPoP-specific tests removed)
- [x] `grep -rni dpop src/ docs/` — 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)