### PR TITLE
perf: render and bundle improvements

### DIFF
--- a/src/components/categories/CategoryRow.tsx
+++ b/src/components/categories/CategoryRow.tsx
@@ -1,4 +1,12 @@
-export function CategoryRow({ name, onStartEdit }: { name: string; onStartEdit: () => void }) {
+import { memo } from 'react';
+
+export const CategoryRow = memo(function CategoryRow({
+  name,
+  onStartEdit,
+}: {
+  name: string;
+  onStartEdit: () => void;
+}) {
   return (
     <li className="flex items-center px-4 py-3 transition-colors hover:bg-muted/30 cursor-pointer">
       <button
@@ -11,4 +19,4 @@ export function CategoryRow({ name, onStartEdit }: { name: string; onStartEdit: 
       </button>
     </li>
   );
-}
+});

--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -43,12 +43,17 @@ export function DashboardPage() {
 
   const [selectedMonth, setSelectedMonth] = useState(currentMonth);
 
-  const firstDayOfPeriod = toLocalIsoDate(new Date(currentYear, selectedMonth, 1));
-  // For past months use the last day of that month; for the current month use today.
-  const lastDayOfPeriod =
-    selectedMonth === currentMonth
-      ? todayIso()
-      : toLocalIsoDate(new Date(currentYear, selectedMonth + 1, 0));
+  const { firstDayOfPeriod, lastDayOfPeriod } = useMemo(
+    () => ({
+      firstDayOfPeriod: toLocalIsoDate(new Date(currentYear, selectedMonth, 1)),
+      // For past months use the last day of that month; for the current month use today.
+      lastDayOfPeriod:
+        selectedMonth === currentMonth
+          ? todayIso()
+          : toLocalIsoDate(new Date(currentYear, selectedMonth + 1, 0)),
+    }),
+    [currentYear, currentMonth, selectedMonth],
+  );
 
   const handleMonthSelect = (month: number) => {
     setSelectedMonth(month);

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -31,7 +31,7 @@ export function MobileNav() {
         className={cn(
           'flex items-center gap-0.5 rounded-full border border-border/40 px-1.5 py-1.5 shadow-xl',
           glassEffect
-            ? 'bg-background/80 shadow-black/10 backdrop-blur-2xl dark:bg-background/70 dark:shadow-black/40'
+            ? 'bg-background/80 shadow-black/10 backdrop-blur-md dark:bg-background/70 dark:shadow-black/40'
             : 'bg-background shadow-black/5',
         )}
       >

--- a/src/components/layout/RootComponent.tsx
+++ b/src/components/layout/RootComponent.tsx
@@ -7,7 +7,9 @@ import { VersionCheck } from '@/components/VersionCheck';
 import { applyTheme, useThemeStore } from '@/stores/theme.store';
 
 export function RootComponent() {
-  const { theme, primaryHue, fontSize } = useThemeStore();
+  const theme = useThemeStore((s) => s.theme);
+  const primaryHue = useThemeStore((s) => s.primaryHue);
+  const fontSize = useThemeStore((s) => s.fontSize);
 
   useEffect(() => {
     applyTheme(theme, primaryHue, fontSize);

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -25,18 +25,16 @@ export function SettingsPage() {
   const queryClient = useQueryClient();
   const { canInstall, promptInstall } = useInstallPrompt();
   const config = getConfig();
-  const {
-    theme,
-    setTheme,
-    primaryHue,
-    setPrimaryHue,
-    fontSize,
-    setFontSize,
-    showNavLabels,
-    setShowNavLabels,
-    glassEffect,
-    setGlassEffect,
-  } = useThemeStore();
+  const theme = useThemeStore((s) => s.theme);
+  const setTheme = useThemeStore((s) => s.setTheme);
+  const primaryHue = useThemeStore((s) => s.primaryHue);
+  const setPrimaryHue = useThemeStore((s) => s.setPrimaryHue);
+  const fontSize = useThemeStore((s) => s.fontSize);
+  const setFontSize = useThemeStore((s) => s.setFontSize);
+  const showNavLabels = useThemeStore((s) => s.showNavLabels);
+  const setShowNavLabels = useThemeStore((s) => s.setShowNavLabels);
+  const glassEffect = useThemeStore((s) => s.glassEffect);
+  const setGlassEffect = useThemeStore((s) => s.setGlassEffect);
 
   const profileUrl = user?.profile?.profile || config.VITE_OIDC_USER_MANAGEMENT_URL;
 

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -1,10 +1,10 @@
 import type { Transaction } from '@budget-buddy-org/budget-buddy-contracts';
 import { useMemo } from 'react';
-import { Badge } from '@/components/ui/badge';
+import { TransactionRow } from '@/components/transactions/TransactionRow';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { formatCurrency, formatDate } from '@/lib/formatters';
+import { formatDate } from '@/lib/formatters';
 
 interface TransactionListProps {
   transactions: Transaction[];
@@ -96,26 +96,12 @@ export function TransactionList({
             </h2>
             <ul className="divide-y">
               {group.items.map((t) => (
-                <li
+                <TransactionRow
                   key={t.id}
-                  className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/30 cursor-pointer"
-                >
-                  <button
-                    type="button"
-                    aria-label={`Edit transaction: ${t.description ?? 'unnamed'}`}
-                    className="min-w-0 flex-1 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-                    onClick={() => onEdit?.(t.id)}
-                  >
-                    <p className="truncate text-sm font-medium">{t.description ?? '—'}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {(t.categoryId && categoryMap[t.categoryId]) || 'No Category'}
-                    </p>
-                  </button>
-                  <Badge variant={t.type === 'INCOME' ? 'income' : 'expense'}>
-                    {t.type === 'INCOME' ? '+' : '-'}
-                    {formatCurrency(t.amount, t.currency)}
-                  </Badge>
-                </li>
+                  transaction={t}
+                  categoryName={t.categoryId ? categoryMap[t.categoryId] : undefined}
+                  onEdit={onEdit}
+                />
               ))}
             </ul>
           </CardContent>

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -91,7 +91,7 @@ export function TransactionList({
       {groupedTransactions.map((group) => (
         <Card key={group.date}>
           <CardContent className="p-0">
-            <h2 className="bg-muted/30 px-4 py-1.5 text-xs font-semibold text-muted-foreground sticky top-0 z-10 backdrop-blur-sm">
+            <h2 className="bg-muted px-4 py-1.5 text-xs font-semibold text-muted-foreground sticky top-0 z-10">
               {formatDate(group.date)}
             </h2>
             <ul className="divide-y">

--- a/src/components/transactions/TransactionRow.tsx
+++ b/src/components/transactions/TransactionRow.tsx
@@ -1,0 +1,34 @@
+import type { Transaction } from '@budget-buddy-org/budget-buddy-contracts';
+import { memo } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { formatCurrency } from '@/lib/formatters';
+
+interface TransactionRowProps {
+  transaction: Transaction;
+  categoryName?: string;
+  onEdit?: (id: string) => void;
+}
+
+export const TransactionRow = memo(function TransactionRow({
+  transaction: t,
+  categoryName,
+  onEdit,
+}: TransactionRowProps) {
+  return (
+    <li className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/30 cursor-pointer">
+      <button
+        type="button"
+        aria-label={`Edit transaction: ${t.description ?? 'unnamed'}`}
+        className="min-w-0 flex-1 cursor-pointer text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        onClick={() => onEdit?.(t.id)}
+      >
+        <p className="truncate text-sm font-medium">{t.description ?? '—'}</p>
+        <p className="text-xs text-muted-foreground">{categoryName || 'No Category'}</p>
+      </button>
+      <Badge variant={t.type === 'INCOME' ? 'income' : 'expense'}>
+        {t.type === 'INCOME' ? '+' : '-'}
+        {formatCurrency(t.amount, t.currency)}
+      </Badge>
+    </li>
+  );
+});

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -43,7 +43,7 @@ function DialogContent({
 }) {
   const contentRef = React.useRef<HTMLDivElement>(null);
   const hiddenCloseRef = React.useRef<HTMLButtonElement>(null);
-  const dragState = React.useRef({ isDragging: false, startY: 0 });
+  const dragState = React.useRef({ isDragging: false, startY: 0, rafId: 0, pendingDelta: 0 });
   // Track pending transitionend listeners so we can clean them up if the
   // component unmounts mid-animation (e.g. portal destruction).
   const pendingListeners = React.useRef<Set<{ el: HTMLElement; fn: () => void }>>(new Set());
@@ -80,35 +80,54 @@ function DialogContent({
     [forwardedRef],
   );
 
+  const cancelPendingFrame = React.useCallback(() => {
+    if (dragState.current.rafId) {
+      cancelAnimationFrame(dragState.current.rafId);
+      dragState.current.rafId = 0;
+    }
+  }, []);
+
   const snapBack = React.useCallback(() => {
     const el = contentRef.current;
     if (!el) return;
     dragState.current.isDragging = false;
+    cancelPendingFrame();
     el.style.transition = 'transform 0.3s ease';
     el.style.transform = 'translateY(0)';
     addTransitionEndListener(el, () => {
       if (contentRef.current) {
         contentRef.current.style.transform = '';
         contentRef.current.style.transition = '';
+        contentRef.current.style.willChange = '';
       }
     });
-  }, [addTransitionEndListener]);
+  }, [addTransitionEndListener, cancelPendingFrame]);
 
   const handlePointerDown = React.useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     e.currentTarget.setPointerCapture(e.pointerId);
-    dragState.current = { isDragging: true, startY: e.clientY };
+    dragState.current = { isDragging: true, startY: e.clientY, rafId: 0, pendingDelta: 0 };
+    if (contentRef.current) {
+      contentRef.current.style.willChange = 'transform';
+      contentRef.current.style.transition = 'none';
+    }
   }, []);
 
   const handlePointerMove = React.useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (!dragState.current.isDragging || !contentRef.current) return;
-    const delta = Math.max(0, e.clientY - dragState.current.startY);
-    contentRef.current.style.transform = `translateY(${delta}px)`;
-    contentRef.current.style.transition = 'none';
+    if (!dragState.current.isDragging) return;
+    dragState.current.pendingDelta = Math.max(0, e.clientY - dragState.current.startY);
+    if (dragState.current.rafId) return;
+    dragState.current.rafId = requestAnimationFrame(() => {
+      dragState.current.rafId = 0;
+      if (contentRef.current) {
+        contentRef.current.style.transform = `translateY(${dragState.current.pendingDelta}px)`;
+      }
+    });
   }, []);
 
   const handlePointerUp = React.useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (!dragState.current.isDragging) return;
+      cancelPendingFrame();
       const delta = e.clientY - dragState.current.startY;
       if (delta > 80) {
         dragState.current.isDragging = false;
@@ -124,7 +143,7 @@ function DialogContent({
         snapBack();
       }
     },
-    [snapBack, addTransitionEndListener],
+    [snapBack, addTransitionEndListener, cancelPendingFrame],
   );
 
   return (

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -27,7 +27,7 @@ function ToastViewport({
 }
 
 const toastVariants = cva(
-  'group pointer-events-auto relative flex w-full items-start gap-3 overflow-hidden rounded-lg border bg-background p-4 pr-10 text-foreground shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full motion-reduce:animate-none motion-reduce:transition-none',
+  'group pointer-events-auto relative flex w-full items-start gap-3 overflow-hidden rounded-lg border bg-background p-4 pr-10 text-foreground shadow-lg transition-transform data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full motion-reduce:animate-none motion-reduce:transition-none',
   {
     variants: {
       variant: {

--- a/src/components/ui/transaction-type-toggle.tsx
+++ b/src/components/ui/transaction-type-toggle.tsx
@@ -46,7 +46,7 @@ export function TransactionTypeToggle({
           aria-selected={value === ''}
           onClick={() => (onChange as NullableProps['onChange'])('')}
           className={cn(
-            'flex-1 flex items-center justify-center gap-2 px-3 rounded-md text-sm font-medium transition-all cursor-pointer select-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+            'flex-1 flex items-center justify-center gap-2 px-3 rounded-md text-sm font-medium transition-colors cursor-pointer select-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
             value === ''
               ? cn(
                   'bg-background text-foreground shadow-sm',
@@ -64,7 +64,7 @@ export function TransactionTypeToggle({
         aria-selected={value === 'EXPENSE'}
         onClick={() => onChange('EXPENSE')}
         className={cn(
-          'flex-1 flex items-center justify-center gap-2 px-3 rounded-md text-sm font-medium transition-all cursor-pointer select-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+          'flex-1 flex items-center justify-center gap-2 px-3 rounded-md text-sm font-medium transition-colors cursor-pointer select-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
           value === 'EXPENSE'
             ? cn(
                 'bg-background text-foreground shadow-sm',
@@ -82,7 +82,7 @@ export function TransactionTypeToggle({
         aria-selected={value === 'INCOME'}
         onClick={() => onChange('INCOME')}
         className={cn(
-          'flex-1 flex items-center justify-center gap-2 px-3 rounded-md text-sm font-medium transition-all cursor-pointer select-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+          'flex-1 flex items-center justify-center gap-2 px-3 rounded-md text-sm font-medium transition-colors cursor-pointer select-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
           value === 'INCOME'
             ? cn(
                 'bg-background text-income shadow-sm',

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -103,25 +103,27 @@ export const allTransactionsQueryOptions = (filters: TransactionFilters = {}) =>
   queryOptions({
     queryKey: [...KEYS.list(filters), 'all'],
     queryFn: async () => {
-      let allItems: Transaction[] = [];
-      let page = 0;
-      let total = 0;
-
-      do {
+      const fetchPage = async (page: number) => {
         const { data, error } = await listTransactions({
-          query: {
-            ...filters,
-            size: PAGE_SIZE_ALL,
-            page,
-          },
+          query: { ...filters, size: PAGE_SIZE_ALL, page },
         });
         if (error) throw error;
-        allItems = [...allItems, ...data.items];
-        total = data.meta.total;
-        page++;
-      } while (allItems.length < total && page < MAX_PAGES_ALL);
+        return data;
+      };
 
-      return { items: allItems, meta: { total } };
+      const first = await fetchPage(0);
+      const total = first.meta.total;
+      const totalPages = Math.min(Math.ceil(total / PAGE_SIZE_ALL), MAX_PAGES_ALL);
+
+      if (totalPages <= 1) return { items: first.items, meta: { total } };
+
+      const rest = await Promise.all(
+        Array.from({ length: totalPages - 1 }, (_, i) => fetchPage(i + 1)),
+      );
+
+      const items: Transaction[] = first.items;
+      for (const page of rest) items.push(...page.items);
+      return { items, meta: { total } };
     },
   });
 

--- a/src/index.css
+++ b/src/index.css
@@ -161,7 +161,7 @@ textarea {
 }
 
 @utility transition-spring {
-  transition-property: transform, opacity, background-color, box-shadow, color, width, height, min-width;
+  transition-property: transform, opacity, background-color, box-shadow, color;
   transition-timing-function: var(--easing-spring);
   transition-duration: 350ms;
 }

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -2,11 +2,31 @@ function browserLocale(): string {
   return (typeof navigator !== 'undefined' && navigator.language) || 'en-US';
 }
 
+const currencyFormatters = new Map<string, Intl.NumberFormat>();
+const dateFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getCurrencyFormatter(locale: string, currency: string): Intl.NumberFormat {
+  const key = `${locale}|${currency}`;
+  let f = currencyFormatters.get(key);
+  if (!f) {
+    f = new Intl.NumberFormat(locale, { style: 'currency', currency });
+    currencyFormatters.set(key, f);
+  }
+  return f;
+}
+
+function getDateFormatter(locale: string): Intl.DateTimeFormat {
+  let f = dateFormatters.get(locale);
+  if (!f) {
+    f = new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'short', day: 'numeric' });
+    dateFormatters.set(locale, f);
+  }
+  return f;
+}
+
 /** Converts minor currency units (e.g. 1299) to a formatted string (e.g. "€12.99"). */
 export function formatCurrency(minorUnits: number, currency = 'EUR', locale?: string): string {
-  return new Intl.NumberFormat(locale ?? browserLocale(), { style: 'currency', currency }).format(
-    minorUnits / 100,
-  );
+  return getCurrencyFormatter(locale ?? browserLocale(), currency).format(minorUnits / 100);
 }
 
 /** Converts a decimal amount (e.g. 12.99) to minor units (e.g. 1299). */
@@ -35,11 +55,7 @@ export function toLocalYearMonth(date: Date): string {
 
 /** Formats an ISO date string (YYYY-MM-DD) for display. */
 export function formatDate(dateString: string, locale?: string): string {
-  return new Intl.DateTimeFormat(locale ?? browserLocale(), {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  }).format(new Date(`${dateString}T00:00:00`));
+  return getDateFormatter(locale ?? browserLocale()).format(new Date(`${dateString}T00:00:00`));
 }
 
 /** Returns today's date as YYYY-MM-DD. */

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -7,6 +7,8 @@ export const router = createRouter({
   defaultPendingComponent: RouteLoader,
   defaultPendingMs: 100,
   defaultPendingMinMs: 300,
+  defaultPreload: 'intent',
+  defaultPreloadStaleTime: 0,
 });
 
 declare module '@tanstack/react-router' {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -121,6 +121,18 @@ export default defineConfig({
           if (id.includes('@tanstack/react-router') || id.includes('@tanstack/router-') || id.includes('@tanstack/history')) {
             return 'vendor-router'
           }
+          if (id.includes('@radix-ui/')) {
+            return 'vendor-radix'
+          }
+          if (id.includes('recharts') || id.includes('d3-')) {
+            return 'vendor-charts'
+          }
+          if (id.includes('oidc-client-ts') || id.includes('react-oidc-context')) {
+            return 'vendor-oidc'
+          }
+          if (id.includes('lucide-react')) {
+            return 'vendor-icons'
+          }
           return 'vendor'
         },
       },


### PR DESCRIPTION
## Summary
- Theme store selectors, intl formatter caching, parallel dashboard fetch
- Dialog drag rAF throttling, reduced backdrop-blur, restricted transition properties
- Router `intent` preload, vendor chunk split, row memoization, dashboard period memo

## Test plan
- [ ] `pnpm lint` clean
- [ ] `pnpm vitest run` — 127 tests pass
- [ ] `pnpm build` succeeds and chunks split as expected
- [ ] Manual: dashboard loads, dialogs drag-to-close on mobile, theme toggle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)