### PR TITLE
feat: wire search and amount-range filters into transactions UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,12 @@ We use page-based pagination for transactions and categories.
 - API: Consumes `meta.total` for correct item count and page calculation.
 - State: Managed at the page level via `useState` and passed to domain hooks.
 
+### Transaction filters
+
+URL search params are the source of truth for transactions list filters. Validation lives in [src/routes/_app/transactions/index.tsx](src/routes/_app/transactions/index.tsx) (`validateSearch`) — keep it `typeof`-based, no Zod. Supported params: `page`, `categoryId`, `start`, `end`, `sort`, `type`, `query`, `amountMin`, `amountMax`. **Amount params are stored in minor units** (integers ≥1) — convert in/out via `toMinorUnits` / `/100` from [src/lib/formatters.ts](src/lib/formatters.ts). Empty inputs must be omitted (`undefined`) — never send empty strings or `0`.
+
+The free-text search box debounces input via [src/hooks/useDebouncedValue.ts](src/hooks/useDebouncedValue.ts) (default 300 ms) so each keystroke does not refetch. The hook is generic — reuse it whenever you need debounced state.
+
 ### Accessibility Testing
 
 We use `vitest-axe` for automated accessibility checks.

--- a/src/components/transactions/TransactionFilters.test.tsx
+++ b/src/components/transactions/TransactionFilters.test.tsx
@@ -61,6 +61,9 @@ describe('TransactionFilters', () => {
     end: '',
     sort: 'desc' as const,
     type: '' as const,
+    query: '',
+    amountMin: undefined,
+    amountMax: undefined,
   };
   const onFilterChange = vi.fn();
   const onReset = vi.fn();
@@ -116,5 +119,38 @@ describe('TransactionFilters', () => {
     const doneButton = screen.getByRole('button', { name: /done/i });
     fireEvent.click(doneButton);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('emits amountMin in minor units when min input changes', () => {
+    onFilterChange.mockClear();
+    render(
+      <TransactionFilters
+        categories={categories}
+        filters={filters}
+        onFilterChange={onFilterChange}
+        onReset={onReset}
+        onClose={onClose}
+      />,
+    );
+
+    const minInput = screen.getByLabelText(/min/i);
+    fireEvent.change(minInput, { target: { value: '12.34' } });
+
+    expect(onFilterChange).toHaveBeenCalledWith(expect.objectContaining({ amountMin: 1234 }));
+  });
+
+  it('shows an error and blocks Done when min > max', () => {
+    render(
+      <TransactionFilters
+        categories={categories}
+        filters={{ ...filters, amountMin: 5000, amountMax: 1000 }}
+        onFilterChange={onFilterChange}
+        onReset={onReset}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/min amount cannot be greater/i);
+    expect(screen.getByRole('button', { name: /done/i })).toBeDisabled();
   });
 });

--- a/src/components/transactions/TransactionFilters.tsx
+++ b/src/components/transactions/TransactionFilters.tsx
@@ -1,9 +1,12 @@
 import { RotateCcw } from 'lucide-react';
+import { useState } from 'react';
+import { AmountInput } from '@/components/ui/amount-input';
 import { Button } from '@/components/ui/button';
 import { DatePicker } from '@/components/ui/date-picker';
 import { Select } from '@/components/ui/select';
 import { TransactionTypeToggle } from '@/components/ui/transaction-type-toggle';
 import type { TransactionPageFilters } from '@/hooks/useTransactionPageState';
+import { toMinorUnits } from '@/lib/formatters';
 
 interface TransactionFiltersProps {
   categories: { id: string; name: string }[];
@@ -13,6 +16,9 @@ interface TransactionFiltersProps {
   onClose: () => void;
 }
 
+const minorToDecimalString = (minor: number | undefined): string =>
+  minor === undefined ? '' : (minor / 100).toFixed(2);
+
 export function TransactionFilters({
   categories,
   filters,
@@ -20,8 +26,37 @@ export function TransactionFilters({
   onReset,
   onClose,
 }: TransactionFiltersProps) {
+  const [minStr, setMinStr] = useState(minorToDecimalString(filters.amountMin));
+  const [maxStr, setMaxStr] = useState(minorToDecimalString(filters.amountMax));
+  const [prevMin, setPrevMin] = useState(filters.amountMin);
+  const [prevMax, setPrevMax] = useState(filters.amountMax);
+  // Sync local input strings when the external filters change (e.g. on Reset).
+  if (prevMin !== filters.amountMin) {
+    setPrevMin(filters.amountMin);
+    setMinStr(minorToDecimalString(filters.amountMin));
+  }
+  if (prevMax !== filters.amountMax) {
+    setPrevMax(filters.amountMax);
+    setMaxStr(minorToDecimalString(filters.amountMax));
+  }
+
+  const minMinor = minStr ? toMinorUnits(Number.parseFloat(minStr)) : undefined;
+  const maxMinor = maxStr ? toMinorUnits(Number.parseFloat(maxStr)) : undefined;
+  const rangeError = minMinor !== undefined && maxMinor !== undefined && minMinor > maxMinor;
+
+  const commitAmounts = (next: { amountMin?: number; amountMax?: number }) => {
+    onFilterChange({ ...filters, ...next });
+  };
+
   const hasActiveFilters =
-    filters.categoryId || filters.start || filters.end || filters.sort !== 'desc' || filters.type;
+    filters.categoryId ||
+    filters.start ||
+    filters.end ||
+    filters.sort !== 'desc' ||
+    filters.type ||
+    filters.query ||
+    filters.amountMin !== undefined ||
+    filters.amountMax !== undefined;
 
   return (
     <div className="space-y-4 pt-2">
@@ -75,6 +110,51 @@ export function TransactionFilters({
         </div>
       </div>
 
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Amount range</legend>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label htmlFor="amount-min-filter" className="text-xs text-muted-foreground">
+              Min
+            </label>
+            <AmountInput
+              id="amount-min-filter"
+              value={minStr}
+              error={rangeError}
+              onChange={(v) => {
+                setMinStr(v);
+                if (rangeError) return;
+                const next = v ? toMinorUnits(Number.parseFloat(v)) : undefined;
+                if (maxMinor !== undefined && next !== undefined && next > maxMinor) return;
+                commitAmounts({ amountMin: next, amountMax: filters.amountMax });
+              }}
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="amount-max-filter" className="text-xs text-muted-foreground">
+              Max
+            </label>
+            <AmountInput
+              id="amount-max-filter"
+              value={maxStr}
+              error={rangeError}
+              onChange={(v) => {
+                setMaxStr(v);
+                if (rangeError) return;
+                const next = v ? toMinorUnits(Number.parseFloat(v)) : undefined;
+                if (minMinor !== undefined && next !== undefined && next < minMinor) return;
+                commitAmounts({ amountMin: filters.amountMin, amountMax: next });
+              }}
+            />
+          </div>
+        </div>
+        {rangeError && (
+          <p role="alert" className="text-xs text-destructive">
+            Min amount cannot be greater than max amount.
+          </p>
+        )}
+      </fieldset>
+
       <div className="space-y-2">
         <label htmlFor="sort-filter" className="text-sm font-medium">
           Sort
@@ -100,7 +180,7 @@ export function TransactionFilters({
           <RotateCcw className="mr-2 size-4" />
           Reset
         </Button>
-        <Button onClick={onClose} className="flex-1">
+        <Button onClick={onClose} className="flex-1" disabled={rangeError}>
           Done
         </Button>
       </div>

--- a/src/components/transactions/TransactionSearchBar.test.tsx
+++ b/src/components/transactions/TransactionSearchBar.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TransactionSearchBar } from './TransactionSearchBar';
+
+describe('TransactionSearchBar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces query input and emits the latest value', () => {
+    const onQueryChange = vi.fn();
+    render(
+      <TransactionSearchBar
+        value=""
+        onQueryChange={onQueryChange}
+        onOpenFilters={() => {}}
+        isFiltered={false}
+      />,
+    );
+
+    const input = screen.getByLabelText(/search transactions/i);
+    fireEvent.change(input, { target: { value: 'co' } });
+    fireEvent.change(input, { target: { value: 'cof' } });
+    fireEvent.change(input, { target: { value: 'coffee' } });
+
+    expect(onQueryChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(onQueryChange).toHaveBeenCalledWith('coffee');
+  });
+
+  it('emits undefined when input is cleared', () => {
+    const onQueryChange = vi.fn();
+    render(
+      <TransactionSearchBar
+        value="coffee"
+        onQueryChange={onQueryChange}
+        onOpenFilters={() => {}}
+        isFiltered={false}
+      />,
+    );
+
+    const clearBtn = screen.getByRole('button', { name: /clear search/i });
+    fireEvent.click(clearBtn);
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(onQueryChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('calls onOpenFilters when filter button is clicked', () => {
+    const onOpenFilters = vi.fn();
+    render(
+      <TransactionSearchBar
+        value=""
+        onQueryChange={() => {}}
+        onOpenFilters={onOpenFilters}
+        isFiltered={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /open filters/i }));
+    expect(onOpenFilters).toHaveBeenCalled();
+  });
+});

--- a/src/components/transactions/TransactionSearchBar.tsx
+++ b/src/components/transactions/TransactionSearchBar.tsx
@@ -1,0 +1,84 @@
+import { Search, SlidersHorizontal, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { cn } from '@/lib/cn';
+
+interface TransactionSearchBarProps {
+  value: string;
+  onQueryChange: (next: string | undefined) => void;
+  onOpenFilters: () => void;
+  isFiltered: boolean;
+}
+
+export function TransactionSearchBar({
+  value,
+  onQueryChange,
+  onOpenFilters,
+  isFiltered,
+}: TransactionSearchBarProps) {
+  const [local, setLocal] = useState(value);
+  const [prevValue, setPrevValue] = useState(value);
+  // Sync external value (e.g. URL reset) into local state during render.
+  if (prevValue !== value) {
+    setPrevValue(value);
+    setLocal(value);
+  }
+
+  const debounced = useDebouncedValue(local, 300);
+  const lastEmittedRef = useRef(value);
+
+  // Push debounced changes upward when they differ from what we last emitted
+  // and from the external value (to avoid echoing URL-driven updates back).
+  useEffect(() => {
+    if (debounced === value || debounced === lastEmittedRef.current) return;
+    lastEmittedRef.current = debounced;
+    onQueryChange(debounced.length > 0 ? debounced : undefined);
+  }, [debounced, value, onQueryChange]);
+
+  return (
+    <search className="flex items-center gap-2">
+      <div className="relative flex-1">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          type="search"
+          aria-label="Search transactions"
+          placeholder="Search"
+          className="rounded-full pl-9 pr-9"
+          value={local}
+          onChange={(e) => setLocal(e.target.value)}
+        />
+        {local.length > 0 && (
+          <button
+            type="button"
+            aria-label="Clear search"
+            onClick={() => setLocal('')}
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X className="size-4" />
+          </button>
+        )}
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        onClick={onOpenFilters}
+        aria-label="Open filters"
+        className={cn('relative size-10 shrink-0 rounded-full')}
+      >
+        <SlidersHorizontal className="size-4" />
+        {isFiltered && (
+          <span
+            aria-hidden="true"
+            className="absolute right-1 top-1 size-2 rounded-full bg-primary"
+          />
+        )}
+      </Button>
+    </search>
+  );
+}

--- a/src/components/transactions/TransactionsPage.tsx
+++ b/src/components/transactions/TransactionsPage.tsx
@@ -1,12 +1,11 @@
 import type { Transaction } from '@budget-buddy-org/budget-buddy-contracts';
 import { useNavigate } from '@tanstack/react-router';
-import { Filter } from 'lucide-react';
 import { useState } from 'react';
 import { PageHeader } from '@/components/layout/PageHeader';
 import { TransactionFilters } from '@/components/transactions/TransactionFilters';
 import { TransactionForm } from '@/components/transactions/TransactionForm';
 import { TransactionList } from '@/components/transactions/TransactionList';
-import { Button } from '@/components/ui/button';
+import { TransactionSearchBar } from '@/components/transactions/TransactionSearchBar';
 import {
   Dialog,
   DialogContent,
@@ -39,6 +38,7 @@ export function TransactionsPage() {
     closeForm,
     resetFilters,
     handleFilterChange,
+    handleQueryChange,
     handlePageChange,
   } = useTransactionPageState();
 
@@ -81,6 +81,9 @@ export function TransactionsPage() {
     start: filters.start || undefined,
     end: filters.end || undefined,
     type: filters.type || undefined,
+    query: filters.query || undefined,
+    amountMin: filters.amountMin,
+    amountMax: filters.amountMax,
   };
 
   const { data, isLoading } = useTransactions(queryFilters);
@@ -96,16 +99,14 @@ export function TransactionsPage() {
           label: 'Add',
           onClick: () => setShowForm((v) => !v),
         }}
-      >
-        <Button
-          variant={showFilters ? 'secondary' : 'outline'}
-          onClick={() => setShowFilters((v) => !v)}
-          aria-label="Toggle filters"
-        >
-          <Filter className="size-4" />
-          {hasActiveFilters && <span className="ml-1 h-1.5 w-1.5 rounded-full bg-primary" />}
-        </Button>
-      </PageHeader>
+      />
+
+      <TransactionSearchBar
+        value={filters.query}
+        onQueryChange={handleQueryChange}
+        onOpenFilters={() => setShowFilters(true)}
+        isFiltered={hasActiveFilters}
+      />
 
       <Dialog open={showFilters} onOpenChange={setShowFilters}>
         <DialogContent>

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/src/hooks/useTransactionPageState.test.ts
+++ b/src/hooks/useTransactionPageState.test.ts
@@ -22,6 +22,9 @@ const DEFAULT_FILTERS: TransactionPageFilters = {
   end: '',
   sort: 'desc',
   type: '',
+  query: '',
+  amountMin: undefined,
+  amountMax: undefined,
 };
 
 beforeEach(() => {
@@ -102,6 +105,9 @@ describe('useTransactionPageState — handleFilterChange', () => {
       end: '2024-01-31',
       sort: 'asc',
       type: 'EXPENSE',
+      query: '',
+      amountMin: undefined,
+      amountMax: undefined,
     };
 
     act(() => result.current.handleFilterChange(newFilters));

--- a/src/hooks/useTransactionPageState.ts
+++ b/src/hooks/useTransactionPageState.ts
@@ -8,6 +8,9 @@ export interface TransactionPageFilters {
   end: string;
   sort: 'asc' | 'desc';
   type: 'EXPENSE' | 'INCOME' | '';
+  query: string;
+  amountMin?: number;
+  amountMax?: number;
 }
 
 const DEFAULT_FILTERS: TransactionPageFilters = {
@@ -16,6 +19,9 @@ const DEFAULT_FILTERS: TransactionPageFilters = {
   end: '',
   sort: 'desc',
   type: '',
+  query: '',
+  amountMin: undefined,
+  amountMax: undefined,
 };
 
 export function useTransactionPageState() {
@@ -32,6 +38,9 @@ export function useTransactionPageState() {
     end: search.end ?? DEFAULT_FILTERS.end,
     sort: search.sort ?? DEFAULT_FILTERS.sort,
     type: search.type ?? DEFAULT_FILTERS.type,
+    query: search.query ?? DEFAULT_FILTERS.query,
+    amountMin: search.amountMin,
+    amountMax: search.amountMax,
   };
 
   const page = search.page ?? 0;
@@ -50,6 +59,9 @@ export function useTransactionPageState() {
         end: undefined,
         sort: undefined,
         type: undefined,
+        query: undefined,
+        amountMin: undefined,
+        amountMax: undefined,
       },
       replace: true,
     });
@@ -65,7 +77,24 @@ export function useTransactionPageState() {
           end: newFilters.end || undefined,
           sort: newFilters.sort !== 'desc' ? newFilters.sort : undefined,
           type: newFilters.type || undefined,
+          query: newFilters.query || undefined,
+          amountMin: newFilters.amountMin,
+          amountMax: newFilters.amountMax,
         },
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
+  const handleQueryChange = useCallback(
+    (next: string | undefined) => {
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          page: undefined,
+          query: next && next.length > 0 ? next : undefined,
+        }),
         replace: true,
       });
     },
@@ -83,7 +112,15 @@ export function useTransactionPageState() {
     [navigate],
   );
 
-  const isFiltered = !!(filters.categoryId || filters.start || filters.end || filters.type);
+  const isFiltered = !!(
+    filters.categoryId ||
+    filters.start ||
+    filters.end ||
+    filters.type ||
+    filters.query ||
+    filters.amountMin !== undefined ||
+    filters.amountMax !== undefined
+  );
   const hasActiveFilters = isFiltered || filters.sort !== 'desc';
 
   return {
@@ -100,6 +137,7 @@ export function useTransactionPageState() {
     closeForm,
     resetFilters,
     handleFilterChange,
+    handleQueryChange,
     handlePageChange,
   };
 }

--- a/src/hooks/useTransactions.test.ts
+++ b/src/hooks/useTransactions.test.ts
@@ -96,6 +96,28 @@ describe('useTransactions', () => {
       }),
     );
   });
+
+  it('forwards search and amount-range filters to the API', async () => {
+    vi.mocked(listTransactions).mockResolvedValue({
+      data: mockPage,
+      error: undefined,
+    } as unknown as ListTransactionsResult);
+
+    renderHook(() => useTransactions({ query: 'coffee', amountMin: 100, amountMax: 5000 }), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(listTransactions).toHaveBeenCalled());
+    expect(listTransactions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'coffee',
+          amountMin: 100,
+          amountMax: 5000,
+        }),
+      }),
+    );
+  });
 });
 
 describe('useCreateTransaction', () => {

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -29,6 +29,9 @@ export interface TransactionFilters {
   end?: string;
   sort?: 'asc' | 'desc';
   type?: TransactionType;
+  query?: string;
+  amountMin?: number;
+  amountMax?: number;
 }
 
 // Client-side "fetch all" limits — the API doesn't support full-text search, so we

--- a/src/routes/_app/transactions/index.a11y.test.tsx
+++ b/src/routes/_app/transactions/index.a11y.test.tsx
@@ -75,7 +75,7 @@ describe('TransactionsPage a11y', () => {
     render(<TransactionsPage />);
 
     // Open filters dialog
-    const filterButton = screen.getByLabelText(/toggle filters/i);
+    const filterButton = screen.getByLabelText(/open filters/i);
     fireEvent.click(filterButton);
 
     // Dialog teleports to body, so we check document.body

--- a/src/routes/_app/transactions/index.tsx
+++ b/src/routes/_app/transactions/index.tsx
@@ -11,7 +11,13 @@ export interface TransactionSearch {
   end?: string;
   sort?: 'asc' | 'desc';
   type?: 'EXPENSE' | 'INCOME' | '';
+  query?: string;
+  amountMin?: number;
+  amountMax?: number;
 }
+
+const validAmount = (v: unknown): number | undefined =>
+  typeof v === 'number' && Number.isFinite(v) && v >= 1 ? Math.floor(v) : undefined;
 
 export const Route = createFileRoute('/_app/transactions/')({
   pendingComponent: TransactionsSkeleton,
@@ -27,6 +33,9 @@ export const Route = createFileRoute('/_app/transactions/')({
         : search.type === ''
           ? ''
           : undefined,
+    query: typeof search.query === 'string' && search.query.length > 0 ? search.query : undefined,
+    amountMin: validAmount(search.amountMin),
+    amountMax: validAmount(search.amountMax),
   }),
   loader: ({ location }) => {
     const search = location.search as TransactionSearch;
@@ -40,6 +49,9 @@ export const Route = createFileRoute('/_app/transactions/')({
           start: search.start || undefined,
           end: search.end || undefined,
           type: search.type || undefined,
+          query: search.query || undefined,
+          amountMin: search.amountMin,
+          amountMax: search.amountMax,
         }),
       ),
       queryClient.ensureQueryData(categoriesQueryOptions()),


### PR DESCRIPTION
## Why

Closes #124.

[budget-buddy-contracts PR #91](https://github.com/budget-buddy-org/budget-buddy-contracts/pull/91) added `query`, `amountMin`, `amountMax` to `GET /v1/transactions`. The `@budget-buddy-org/budget-buddy-contracts@^3.2.0` already in `package.json` exposes them — this PR just wires them through the UI.

UI direction is Revolut-inspired per the issue request: a prominent rounded search input with a circular filter button beside it.

## What changed

- New `src/components/transactions/TransactionSearchBar.tsx`: rounded search input with leading icon, optional clear button, and a circular filter button with an indicator dot when filters are active. Debounces input via the new generic `useDebouncedValue` hook (300 ms).
- New `src/hooks/useDebouncedValue.ts`: tiny generic debounce hook.
- `src/routes/_app/transactions/index.tsx`: extends `TransactionSearch` and `validateSearch` with `query`, `amountMin`, `amountMax` (typeof-guarded; ≥1 integer for amounts) and forwards them through the loader.
- `src/hooks/useTransactionPageState.ts`: surfaces the new params, adds `handleQueryChange`, includes them in `isFiltered`, drops empties.
- `src/hooks/useTransactions.ts`: extends `TransactionFilters` interface — new fields are picked up automatically by the existing `KEYS.list(filters)` cache key and the `...filters` spread into `listTransactions`.
- `src/components/transactions/TransactionFilters.tsx`: adds a Min/Max amount range row using `AmountInput`. Values converted via `toMinorUnits`. Min > max shows an inline error and disables Done.
- `src/components/transactions/TransactionsPage.tsx`: replaces the header filter button with the new `TransactionSearchBar`.
- `CLAUDE.md`: documents the URL filter shape (with amounts in minor units) and the debounce convention.
- Tests: added `TransactionSearchBar.test.tsx`, extended `useTransactions.test.ts` and `TransactionFilters.test.tsx`, updated `useTransactionPageState.test.ts` and `index.a11y.test.tsx` for the new aria-label.

## Acceptance criteria

- ✅ Bump `@budget-buddy/contracts` — N/A, already on `^3.2.0` which includes the new params.
- ✅ Search input mapped to `query`, debounced (`TransactionSearchBar` + `useDebouncedValue`).
- ✅ Min/Max amount inputs mapped to `amountMin`/`amountMax` in minor units (`TransactionFilters` via `toMinorUnits`).
- ✅ New filters included in the TanStack Query key — `KEYS.list(filters)` already keys on the entire filters object.
- ✅ Filter state reflected in URL search params (`validateSearch` + `useTransactionPageState`).
- ✅ Empty inputs omit the param entirely — never empty strings or `0`.

## How to verify

1. `pnpm install && pnpm lint && pnpm type-check && pnpm test` (all green).
2. `pnpm dev`, visit `/transactions`.
3. Type in the search box → after ~300 ms the URL gets `?query=...` and results filter.
4. Click the filter button → enter Min `1.00` and Max `5.00` → URL contains `amountMin=100&amountMax=500`; results filter.
5. Set Min > Max → inline error appears, Done is disabled, no extra requests fire.
6. Clear inputs → params drop off the URL (no empty-string/0 params).
7. Bookmark a filtered URL and reload → state restored end-to-end.