### PR TITLE
feat(dashboard): use GET /v1/transactions/summary; remove useAllTransactions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,10 @@ The application uses standalone functional API calls (e.g. `listTransactions`, `
 
 TanStack Query v5. All query/mutation logic lives in hooks under `src/hooks/`. Each domain hook file (e.g. `useTransactions.ts`, `useCategories.ts`) exports a `KEYS` object for consistent cache key management, plus hooks for list, detail, create, update, and delete. Delete mutations use optimistic updates with rollback via `onMutate`/`onError`.
 
-- **Dashboard data sources:** The Dashboard composes three fetches:
+- **Dashboard data sources:** The Dashboard composes three fetches that TanStack Query parallelises automatically:
   - `useCategoriesSummary({ month, currency })` ([src/hooks/useCategoriesSummary.ts](src/hooks/useCategoriesSummary.ts)) — server-side per-category aggregation (`spent`, `monthlyBudget`, `excludedTransactionCount`). Source of truth for the "Expenses by category" section.
+  - `useMonthlySummary({ month, currency })` ([src/hooks/useMonthlySummary.ts](src/hooks/useMonthlySummary.ts)) — server-side monthly totals (`income`, `expense`, `balance`, `incomeCount`, `expenseCount`, `excludedTransactionCount`). Source of truth for the Balance / Income / Expenses cards.
   - `useTransactions({ size: 5, ... })` — recent transactions list.
-  - `useAllTransactions` — still used **only** to compute income/expense/balance totals client-side, since no income aggregation endpoint exists yet. Capped at 2,000 transactions.
   Text search is server-side via the contracts `query` param — never filter locally.
 
 Global error logging is wired into `QueryCache` and `MutationCache` in `src/lib/query-client.ts` — don't add duplicate error reporting inside individual hooks.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deploy": "pnpm run build && wrangler deploy"
   },
   "dependencies": {
-    "@budget-buddy-org/budget-buddy-contracts": "^3.3.0",
+    "@budget-buddy-org/budget-buddy-contracts": "^3.4.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-separator": "^1.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@budget-buddy-org/budget-buddy-contracts':
-        specifier: ^3.3.0
-        version: 3.3.0
+        specifier: ^3.4.0
+        version: 3.4.0
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -791,8 +791,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@budget-buddy-org/budget-buddy-contracts@3.3.0':
-    resolution: {integrity: sha512-/NgOBP5CIGyjDgC++rqJ0w+ktCP2LLaKEEs/YYyTJ7pAZzQjF1S253JF/xQZIhviTxJPJKOiCLpSRk/TTWxKLg==, tarball: https://npm.pkg.github.com/download/@budget-buddy-org/budget-buddy-contracts/3.3.0/b99097b0e8706e100c14d78fe0083c0654573959}
+  '@budget-buddy-org/budget-buddy-contracts@3.4.0':
+    resolution: {integrity: sha512-VyTYXKNP3Z7aAfKaRri03gKKsMstM/zPwoJwh41XD3rzoYa3DfuMZ1p+xS+VIeQdeI25YD5fbJTXiaohEg9Now==, tarball: https://npm.pkg.github.com/download/@budget-buddy-org/budget-buddy-contracts/3.4.0/438093c12a375c732456df3d46173c4aff63ecc6}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -6232,7 +6232,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@budget-buddy-org/budget-buddy-contracts@3.3.0': {}
+  '@budget-buddy-org/budget-buddy-contracts@3.4.0': {}
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 

--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -13,7 +13,8 @@ import { ListItem } from '@/components/ui/list-item';
 import { PageContainer } from '@/components/ui/page-container';
 import { useCategoriesSummary } from '@/hooks/useCategoriesSummary';
 import { useFormatters } from '@/hooks/useFormatters';
-import { useAllTransactions, useTransactions } from '@/hooks/useTransactions';
+import { useMonthlySummary } from '@/hooks/useMonthlySummary';
+import { useTransactions } from '@/hooks/useTransactions';
 import { getCategoryColor } from '@/lib/categoryColor';
 import { cn } from '@/lib/cn';
 import { localeCurrency, todayIso, toLocalIsoDate, toLocalYearMonth } from '@/lib/formatters';
@@ -77,12 +78,9 @@ export function DashboardPage() {
     currency: preferredCurrency,
   });
 
-  // Income/expense totals: no server-side aggregation endpoint exists yet, so we
-  // still rely on a (capped) client-side sum across the period's transactions.
-  const { data: txData, isLoading: txLoading } = useAllTransactions({
-    start: firstDayOfPeriod,
-    end: lastDayOfPeriod,
-    sort: 'desc',
+  const { data: monthlySummary, isLoading: monthlyLoading } = useMonthlySummary({
+    month: periodMonth,
+    currency: preferredCurrency,
   });
 
   const { data: recentData, isLoading: recentLoading } = useTransactions({
@@ -92,15 +90,10 @@ export function DashboardPage() {
     size: 5,
   });
 
-  const { totals, balance } = useMemo(() => {
-    let income = 0;
-    let expense = 0;
-    for (const t of txData?.items ?? []) {
-      if (t.type === 'INCOME') income += t.amount;
-      else expense += t.amount;
-    }
-    return { totals: { income, expense }, balance: income - expense };
-  }, [txData]);
+  const income = monthlySummary?.income ?? 0;
+  const expense = monthlySummary?.expense ?? 0;
+  const balance = monthlySummary?.balance ?? 0;
+  const monthlyExcludedCount = monthlySummary?.excludedTransactionCount ?? 0;
 
   const { categoryRows, excludedCount } = useMemo(() => {
     const items = summaryData?.items ?? [];
@@ -117,10 +110,10 @@ export function DashboardPage() {
     return { categoryRows: rows, excludedCount: excluded };
   }, [summaryData]);
 
-  const currency = summaryData?.currency ?? preferredCurrency;
+  const currency = monthlySummary?.currency ?? summaryData?.currency ?? preferredCurrency;
   const recent = recentData?.items ?? [];
 
-  if (summaryLoading || txLoading || recentLoading) return <DashboardSkeleton />;
+  if (summaryLoading || monthlyLoading || recentLoading) return <DashboardSkeleton />;
 
   const visibleRows = showAll ? categoryRows : categoryRows.slice(0, VISIBLE_COUNT);
   const hiddenCount = categoryRows.length - VISIBLE_COUNT;
@@ -176,7 +169,7 @@ export function DashboardPage() {
 
         <SummaryCard
           label="Income"
-          amount={totals.income}
+          amount={income}
           currency={currency}
           icon={<ArrowUpRight className="size-4 text-income" />}
           className="text-income"
@@ -184,13 +177,21 @@ export function DashboardPage() {
         />
         <SummaryCard
           label="Expenses"
-          amount={totals.expense}
+          amount={expense}
           currency={currency}
           icon={<ArrowDownRight className="size-4 text-expense" />}
           className="text-expense"
           linkSearch={{ type: 'EXPENSE', start: firstDayOfPeriod, end: lastDayOfPeriod }}
         />
       </div>
+
+      {monthlyExcludedCount > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {monthlyExcludedCount === 1
+            ? '1 transaction in another currency not shown'
+            : `${monthlyExcludedCount} transactions in other currencies not shown`}
+        </p>
+      )}
 
       {/* Expenses by category */}
       <Card>

--- a/src/hooks/useMonthlySummary.test.ts
+++ b/src/hooks/useMonthlySummary.test.ts
@@ -1,0 +1,84 @@
+import { getTransactionsSummary } from '@budget-buddy-org/budget-buddy-contracts';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUserPreferencesStore } from '@/stores/user-preferences.store';
+import { useMonthlySummary } from './useMonthlySummary';
+
+type GetTransactionsSummaryResult = Awaited<ReturnType<typeof getTransactionsSummary>>;
+
+vi.mock('@budget-buddy-org/budget-buddy-contracts', () => ({
+  getTransactionsSummary: vi.fn(),
+}));
+
+const mockSummary = {
+  month: '2024-01',
+  currency: 'EUR',
+  income: 250000,
+  expense: 132450,
+  balance: 117550,
+  incomeCount: 3,
+  expenseCount: 7,
+  excludedTransactionCount: 0,
+};
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('useMonthlySummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUserPreferencesStore.setState({ currency: null });
+  });
+
+  it('returns the fetched summary and forwards month + currency', async () => {
+    vi.mocked(getTransactionsSummary).mockResolvedValue({
+      data: mockSummary,
+      error: undefined,
+    } as unknown as GetTransactionsSummaryResult);
+
+    const { result } = renderHook(() => useMonthlySummary({ month: '2024-01', currency: 'EUR' }), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.balance).toBe(117550);
+    expect(getTransactionsSummary).toHaveBeenCalledWith({
+      query: { month: '2024-01', currency: 'EUR' },
+    });
+  });
+
+  it('falls back to the user-preferences currency when none is provided', async () => {
+    useUserPreferencesStore.setState({ currency: 'GBP' });
+    vi.mocked(getTransactionsSummary).mockResolvedValue({
+      data: { ...mockSummary, currency: 'GBP' },
+      error: undefined,
+    } as unknown as GetTransactionsSummaryResult);
+
+    renderHook(() => useMonthlySummary({ month: '2024-02' }), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(getTransactionsSummary).toHaveBeenCalled());
+    expect(getTransactionsSummary).toHaveBeenCalledWith({
+      query: { month: '2024-02', currency: 'GBP' },
+    });
+  });
+
+  it('falls back to the locale currency when no preference is set', async () => {
+    vi.mocked(getTransactionsSummary).mockResolvedValue({
+      data: mockSummary,
+      error: undefined,
+    } as unknown as GetTransactionsSummaryResult);
+
+    renderHook(() => useMonthlySummary({ month: '2024-03' }), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(getTransactionsSummary).toHaveBeenCalled());
+    const call = vi.mocked(getTransactionsSummary).mock.calls[0]?.[0];
+    expect(call?.query.month).toBe('2024-03');
+    expect(typeof call?.query.currency).toBe('string');
+    expect(call?.query.currency).toMatch(/^[A-Z]{3}$/);
+  });
+});

--- a/src/hooks/useMonthlySummary.ts
+++ b/src/hooks/useMonthlySummary.ts
@@ -1,0 +1,33 @@
+import { getTransactionsSummary } from '@budget-buddy-org/budget-buddy-contracts';
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import { localeCurrency, toLocalYearMonth } from '@/lib/formatters';
+import { useUserPreferencesStore } from '@/stores/user-preferences.store';
+
+export interface MonthlySummaryFilters {
+  month?: string;
+  currency?: string;
+}
+
+const KEYS = {
+  all: ['transactions-summary'] as const,
+  summary: (month: string, currency: string) => ['transactions-summary', month, currency] as const,
+};
+
+export const monthlySummaryQueryOptions = (month: string, currency: string) =>
+  queryOptions({
+    queryKey: KEYS.summary(month, currency),
+    queryFn: async () => {
+      const { data, error } = await getTransactionsSummary({
+        query: { month, currency },
+      });
+      if (error) throw error;
+      return data;
+    },
+  });
+
+export function useMonthlySummary(filters: MonthlySummaryFilters = {}) {
+  const preferredCurrency = useUserPreferencesStore((s) => s.currency);
+  const month = filters.month ?? toLocalYearMonth(new Date());
+  const currency = filters.currency ?? preferredCurrency ?? localeCurrency();
+  return useQuery(monthlySummaryQueryOptions(month, currency));
+}

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -1,6 +1,5 @@
 import type {
   PaginatedTransactions,
-  Transaction,
   TransactionType,
   TransactionUpdate,
   TransactionWrite,
@@ -34,11 +33,6 @@ export interface TransactionFilters {
   amountMin?: number;
   amountMax?: number;
 }
-
-// Dashboard aggregation pulls every transaction across multiple pages because the API
-// has no aggregation endpoint. MAX_PAGES_ALL caps the fan-out at 2000 rows.
-const PAGE_SIZE_ALL = 200;
-const MAX_PAGES_ALL = 10;
 
 export const TRANSACTIONS_PAGE_SIZE = 20;
 
@@ -95,37 +89,6 @@ export const infiniteTransactionsQueryOptions = (filters: TransactionFilters = {
 
 export function useInfiniteTransactions(filters: TransactionFilters = {}) {
   return useInfiniteQuery(infiniteTransactionsQueryOptions(filters));
-}
-export const allTransactionsQueryOptions = (filters: TransactionFilters = {}) =>
-  queryOptions({
-    queryKey: [...KEYS.list(filters), 'all'],
-    queryFn: async () => {
-      const fetchPage = async (page: number) => {
-        const { data, error } = await listTransactions({
-          query: { ...filters, size: PAGE_SIZE_ALL, page },
-        });
-        if (error) throw error;
-        return data;
-      };
-
-      const first = await fetchPage(0);
-      const total = first.meta.total;
-      const totalPages = Math.min(Math.ceil(total / PAGE_SIZE_ALL), MAX_PAGES_ALL);
-
-      if (totalPages <= 1) return { items: first.items, meta: { total } };
-
-      const rest = await Promise.all(
-        Array.from({ length: totalPages - 1 }, (_, i) => fetchPage(i + 1)),
-      );
-
-      const items: Transaction[] = first.items;
-      for (const page of rest) items.push(...page.items);
-      return { items, meta: { total } };
-    },
-  });
-
-export function useAllTransactions(filters: TransactionFilters = {}) {
-  return useQuery(allTransactionsQueryOptions(filters));
 }
 
 export const transactionDetailQueryOptions = (id: string) =>

--- a/src/routes/_app/index.a11y.test.tsx
+++ b/src/routes/_app/index.a11y.test.tsx
@@ -23,8 +23,8 @@ vi.mock('@/hooks/useCategories', () => ({
   }),
 }));
 
-vi.mock('@/hooks/useTransactions', () => {
-  const mockData = {
+vi.mock('@/hooks/useTransactions', () => ({
+  useTransactions: () => ({
     data: {
       items: [
         {
@@ -48,12 +48,24 @@ vi.mock('@/hooks/useTransactions', () => {
       ],
     },
     isLoading: false,
-  };
-  return {
-    useTransactions: () => mockData,
-    useAllTransactions: () => mockData,
-  };
-});
+  }),
+}));
+
+vi.mock('@/hooks/useMonthlySummary', () => ({
+  useMonthlySummary: () => ({
+    data: {
+      month: '2024-03',
+      currency: 'EUR',
+      income: 10000,
+      expense: 5000,
+      balance: 5000,
+      incomeCount: 1,
+      expenseCount: 1,
+      excludedTransactionCount: 0,
+    },
+    isLoading: false,
+  }),
+}));
 
 describe('DashboardPage a11y', () => {
   it('should have no accessibility violations', async () => {

--- a/src/routes/_app/index.lazy.test.tsx
+++ b/src/routes/_app/index.lazy.test.tsx
@@ -12,7 +12,6 @@ vi.mock('@tanstack/react-router', () => ({
 }));
 
 vi.mock('@/hooks/useTransactions', () => ({
-  useAllTransactions: vi.fn(),
   useTransactions: vi.fn(),
 }));
 
@@ -20,8 +19,13 @@ vi.mock('@/hooks/useCategoriesSummary', () => ({
   useCategoriesSummary: vi.fn(),
 }));
 
+vi.mock('@/hooks/useMonthlySummary', () => ({
+  useMonthlySummary: vi.fn(),
+}));
+
 import { useCategoriesSummary } from '@/hooks/useCategoriesSummary';
-import { useAllTransactions, useTransactions } from '@/hooks/useTransactions';
+import { useMonthlySummary } from '@/hooks/useMonthlySummary';
+import { useTransactions } from '@/hooks/useTransactions';
 
 const mockTransactions = [
   {
@@ -43,6 +47,17 @@ const mockTransactions = [
     categoryId: '2',
   },
 ];
+
+const mockMonthlySummary = {
+  month: '2026-04',
+  currency: 'EUR',
+  income: 10000,
+  expense: 5000,
+  balance: 5000,
+  incomeCount: 1,
+  expenseCount: 1,
+  excludedTransactionCount: 0,
+};
 
 describe('DashboardPage', () => {
   beforeEach(() => {
@@ -72,6 +87,11 @@ describe('DashboardPage', () => {
       data: { items: [], meta: { total: 0, size: 5, page: 0 } },
       isLoading: false,
     } as unknown as ReturnType<typeof useTransactions>);
+
+    vi.mocked(useMonthlySummary).mockReturnValue({
+      data: mockMonthlySummary,
+      isLoading: false,
+    } as ReturnType<typeof useMonthlySummary>);
   });
 
   afterEach(() => {
@@ -79,26 +99,16 @@ describe('DashboardPage', () => {
   });
 
   it('shows income, expense and balance totals for the month', async () => {
-    vi.mocked(useAllTransactions).mockReturnValue({
-      data: {
-        items: mockTransactions,
-      },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useAllTransactions>);
-
     render(<DashboardPage />);
 
-    // Items: 10000 income, 5000 expense. Balance = 50.00
+    // mockMonthlySummary: 10000 income, 5000 expense, 5000 balance (all minor units → €100/€50/€50)
 
-    // Income card
     const incomeCard = screen.getByText('Income').closest('.rounded-lg');
     expect(incomeCard).toHaveTextContent(/100/);
 
-    // Expense card
     const expenseCard = screen.getByText('Expenses').closest('.rounded-lg');
     expect(expenseCard).toHaveTextContent(/50/);
 
-    // Balance card
     const balanceCard = screen.getByText('Balance').closest('.rounded-lg');
     expect(balanceCard).toHaveTextContent(/50/);
   });
@@ -106,12 +116,6 @@ describe('DashboardPage', () => {
   it('navigates to transaction list on click', async () => {
     const mockNavigate = vi.fn();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate);
-    vi.mocked(useAllTransactions).mockReturnValue({
-      data: {
-        items: mockTransactions,
-      },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useAllTransactions>);
     vi.mocked(useTransactions).mockReturnValue({
       data: { items: mockTransactions, meta: { total: 2, size: 5, page: 0 } },
       isLoading: false,
@@ -126,11 +130,6 @@ describe('DashboardPage', () => {
   });
 
   it('renders summary rows with budget progress and the spent / budget label', async () => {
-    vi.mocked(useAllTransactions).mockReturnValue({
-      data: { items: [] },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useAllTransactions>);
-
     render(<DashboardPage />);
 
     expect(screen.getByText('Transport')).toBeInTheDocument();
@@ -138,28 +137,11 @@ describe('DashboardPage', () => {
     expect(screen.getByText(/50\.00.*100\.00/)).toBeInTheDocument();
   });
 
-  it('shows the excluded-transactions note when excludedTransactionCount > 0', async () => {
-    vi.mocked(useCategoriesSummary).mockReturnValue({
-      data: {
-        month: '2026-04',
-        currency: 'EUR',
-        items: [
-          {
-            categoryId: '2',
-            categoryName: 'Transport',
-            monthlyBudget: null,
-            spent: 5000,
-            transactionCount: 1,
-            excludedTransactionCount: 3,
-          },
-        ],
-      },
+  it('shows the excluded-transactions note when monthly excludedTransactionCount > 0', async () => {
+    vi.mocked(useMonthlySummary).mockReturnValue({
+      data: { ...mockMonthlySummary, excludedTransactionCount: 3 },
       isLoading: false,
-    } as ReturnType<typeof useCategoriesSummary>);
-    vi.mocked(useAllTransactions).mockReturnValue({
-      data: { items: [] },
-      isLoading: false,
-    } as unknown as ReturnType<typeof useAllTransactions>);
+    } as ReturnType<typeof useMonthlySummary>);
 
     render(<DashboardPage />);
 

--- a/src/routes/_app/index.tsx
+++ b/src/routes/_app/index.tsx
@@ -1,25 +1,19 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
 import { categoriesQueryOptions } from '@/hooks/useCategories';
-import { allTransactionsQueryOptions } from '@/hooks/useTransactions';
-import { todayIso, toLocalIsoDate } from '@/lib/formatters';
+import { monthlySummaryQueryOptions } from '@/hooks/useMonthlySummary';
+import { localeCurrency, toLocalYearMonth } from '@/lib/formatters';
 import { queryClient } from '@/lib/query-client';
+import { useUserPreferencesStore } from '@/stores/user-preferences.store';
 
 export const Route = createFileRoute('/_app/')({
   pendingComponent: DashboardSkeleton,
   loader: () => {
-    const now = new Date();
-    const firstDayOfMonth = toLocalIsoDate(new Date(now.getFullYear(), now.getMonth(), 1));
-    const today = todayIso();
+    const month = toLocalYearMonth(new Date());
+    const currency = useUserPreferencesStore.getState().currency ?? localeCurrency();
 
     return Promise.all([
-      queryClient.ensureQueryData(
-        allTransactionsQueryOptions({
-          start: firstDayOfMonth,
-          end: today,
-          sort: 'desc',
-        }),
-      ),
+      queryClient.ensureQueryData(monthlySummaryQueryOptions(month, currency)),
       queryClient.ensureQueryData(categoriesQueryOptions()),
     ]);
   },


### PR DESCRIPTION
## Why

Closes #136. The dashboard's three summary cards (income, expense, balance) used `useAllTransactions`, which fan-out paginated `listTransactions` calls — up to 2,000 transactions per dashboard mount, silently truncated above the cap. Contracts v3.4.0 added `GET /v1/transactions/summary`, and the API implementation lives in [budget-buddy-api#160](https://github.com/budget-buddy-org/budget-buddy-api/pull/160).

> ⚠️ **Merge order:** wait until the API PR is merged + deployed before merging this one.

## What changed

- **Bump** `@budget-buddy-org/budget-buddy-contracts` 3.3.0 → 3.4.0
- **New** [`useMonthlySummary`](src/hooks/useMonthlySummary.ts) hook — mirrors `useCategoriesSummary` exactly (query-key shape, currency fallback chain, default month). Backed by the generated `getTransactionsSummary` SDK method.
- **New** [`useMonthlySummary.test.ts`](src/hooks/useMonthlySummary.test.ts) — three cases parallel to `useCategoriesSummary.test.ts`
- **Dashboard** ([DashboardPage.tsx](src/components/dashboard/DashboardPage.tsx)): pulls `income`, `expense`, `balance`, `excludedTransactionCount` straight from the new hook. The two summary queries run in parallel (TanStack Query). New informational note below the summary cards: `"N transactions in other currencies not shown"` when `excludedTransactionCount > 0`.
- **Delete** `useAllTransactions`, `allTransactionsQueryOptions`, `PAGE_SIZE_ALL`, `MAX_PAGES_ALL`, and the unused `Transaction` type import from [useTransactions.ts](src/hooks/useTransactions.ts)
- **Route loader** ([routes/_app/index.tsx](src/routes/_app/index.tsx)): preloads `monthlySummaryQueryOptions` instead of `allTransactionsQueryOptions`
- **Tests** — `routes/_app/index.lazy.test.tsx` and `routes/_app/index.a11y.test.tsx` updated to mock `useMonthlySummary` instead of `useAllTransactions`
- **Docs** — [CLAUDE.md](CLAUDE.md) Dashboard data sources section refreshed; client-side cap note removed

## Acceptance criteria

- ✅ Bump `@budget-buddy/contracts` (TS) to the new version
- ✅ Add `useMonthlySummary(month, currency)` query hook
- ✅ Wire dashboard's three summary cards to the new hook
- ✅ Surface `excludedTransactionCount` with the same UX as `categories/summary`
- ✅ Delete `useAllTransactions` and its multi-page accumulator
- ✅ No other call sites depend on it (verified via grep)
- ✅ Loading + error states match `useCategoriesSummary` patterns
- 🔍 Manual smoke: pending API deploy

## How to verify

```bash
pnpm install
pnpm lint
pnpm type-check
pnpm test
pnpm test:a11y
```

Manual smoke (against an API build with [budget-buddy-api#160](https://github.com/budget-buddy-org/budget-buddy-api/pull/160) merged):
- [ ] Dashboard renders correct income / expense / balance for the current month
- [ ] Switching months re-aggregates correctly
- [ ] Fresh account (zero transactions) → zeros, no errors
- [ ] Transaction in a non-preferred currency → "N transactions in other currencies not shown" note appears
- [ ] DevTools Network: a single `GET /v1/transactions/summary` request, no fan-out paginated `listTransactions` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)