### PR TITLE
fix(categories): allow zero monthly budget; refresh dashboard after edits

### DIFF
--- a/src/components/categories/CategoriesPage.tsx
+++ b/src/components/categories/CategoriesPage.tsx
@@ -36,7 +36,7 @@ function inputToMinorUnits(value: string): number | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
   const parsed = Number(trimmed);
-  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
   return toMinorUnits(parsed);
 }
 

--- a/src/components/categories/CategoryForm.tsx
+++ b/src/components/categories/CategoryForm.tsx
@@ -54,6 +54,7 @@ export function CategoryForm({
           id="category-monthly-budget"
           value={monthlyBudget}
           onChange={onMonthlyBudgetChange}
+          allowZero
         />
       </FormField>
 

--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -210,11 +210,15 @@ export function DashboardPage() {
               <ul className="space-y-3">
                 {visibleRows.map((row) => {
                   const color = getCategoryColor(row.name);
-                  const hasBudget = row.monthlyBudget != null && row.monthlyBudget > 0;
-                  const pct = hasBudget
-                    ? Math.min(100, Math.round((row.spent / (row.monthlyBudget as number)) * 100))
-                    : 0;
-                  const overBudget = hasBudget && row.spent > (row.monthlyBudget as number);
+                  const hasBudget = row.monthlyBudget != null;
+                  const budget = row.monthlyBudget ?? 0;
+                  const pct =
+                    budget > 0
+                      ? Math.min(100, Math.round((row.spent / budget) * 100))
+                      : row.spent > 0
+                        ? 100
+                        : 0;
+                  const overBudget = hasBudget && row.spent > budget;
                   return (
                     <li key={row.categoryId}>
                       <Link

--- a/src/components/ui/amount-input.test.tsx
+++ b/src/components/ui/amount-input.test.tsx
@@ -53,4 +53,22 @@ describe('AmountInput', () => {
     await userEvent.type(input, '{backspace}');
     expect(onChange).toHaveBeenLastCalledWith('');
   });
+
+  it('clears the field when the only digit is "0" and zero is not allowed', async () => {
+    const onChange = vi.fn();
+    render(<AmountInput value="" onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+
+    await userEvent.type(input, '0');
+    expect(onChange).toHaveBeenLastCalledWith('');
+  });
+
+  it('keeps zero as "0.00" when allowZero is set', async () => {
+    const onChange = vi.fn();
+    render(<AmountInput value="" onChange={onChange} allowZero />);
+    const input = screen.getByRole('textbox');
+
+    await userEvent.type(input, '0');
+    expect(onChange).toHaveBeenLastCalledWith('0.00');
+  });
 });

--- a/src/components/ui/amount-input.tsx
+++ b/src/components/ui/amount-input.tsx
@@ -8,9 +8,19 @@ export interface AmountInputProps
   onChange: (value: string) => void;
   ref?: React.Ref<HTMLInputElement>;
   error?: boolean;
+  /** When true, "0" is a valid amount (kept as "0.00"). Default false — zero clears the field. */
+  allowZero?: boolean;
 }
 
-function AmountInput({ className, value, onChange, ref, error, ...props }: AmountInputProps) {
+function AmountInput({
+  className,
+  value,
+  onChange,
+  ref,
+  error,
+  allowZero = false,
+  ...props
+}: AmountInputProps) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     // Extract digits only
     const digits = e.target.value.replaceAll(/\D/g, '');
@@ -22,7 +32,7 @@ function AmountInput({ className, value, onChange, ref, error, ...props }: Amoun
 
     // Convert to a number (e.g. 1299) then back to decimal string (e.g. 12.99)
     const numericValue = Number.parseInt(digits, 10);
-    if (numericValue === 0) {
+    if (numericValue === 0 && !allowZero) {
       onChange('');
       return;
     }

--- a/src/hooks/useCategories.test.ts
+++ b/src/hooks/useCategories.test.ts
@@ -160,6 +160,25 @@ describe('useUpdateCategory', () => {
       body: { name: 'Food' },
     });
   });
+
+  it('invalidates the categories-summary cache after a successful update', async () => {
+    vi.mocked(updateCategory).mockResolvedValue({
+      data: { ...mockCategory, monthlyBudget: 50000 },
+      error: undefined,
+    } as unknown as UpdateCategoryResult);
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: qc }, children);
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateCategory('cat-1'), { wrapper });
+
+    result.current.mutate({ monthlyBudget: 50000 });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['categories-summary'] });
+  });
 });
 
 describe('useDeleteCategory', () => {

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -11,6 +11,7 @@ import {
   updateCategory,
 } from '@budget-buddy-org/budget-buddy-contracts';
 import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CATEGORIES_SUMMARY_KEYS } from '@/hooks/useCategoriesSummary';
 
 export const CATEGORIES_PAGE_SIZE = 200;
 
@@ -63,7 +64,10 @@ export function useCreateCategory() {
       if (error) throw error;
       return data;
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: KEYS.all }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.all });
+      qc.invalidateQueries({ queryKey: CATEGORIES_SUMMARY_KEYS.all });
+    },
   });
 }
 
@@ -81,6 +85,7 @@ export function useUpdateCategory(id: string) {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: KEYS.all });
       qc.invalidateQueries({ queryKey: KEYS.detail(id) });
+      qc.invalidateQueries({ queryKey: CATEGORIES_SUMMARY_KEYS.all });
     },
   });
 }
@@ -117,6 +122,9 @@ export function useDeleteCategory() {
       // Also remove the specific detail query if it exists
       qc.removeQueries({ queryKey: KEYS.detail(id) });
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: KEYS.all }),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: KEYS.all });
+      qc.invalidateQueries({ queryKey: CATEGORIES_SUMMARY_KEYS.all });
+    },
   });
 }

--- a/src/hooks/useCategoriesSummary.ts
+++ b/src/hooks/useCategoriesSummary.ts
@@ -8,14 +8,14 @@ export interface CategoriesSummaryFilters {
   currency?: string;
 }
 
-const KEYS = {
+export const CATEGORIES_SUMMARY_KEYS = {
   all: ['categories-summary'] as const,
   summary: (month: string, currency: string) => ['categories-summary', month, currency] as const,
 };
 
 export const categoriesSummaryQueryOptions = (month: string, currency: string) =>
   queryOptions({
-    queryKey: KEYS.summary(month, currency),
+    queryKey: CATEGORIES_SUMMARY_KEYS.summary(month, currency),
     queryFn: async () => {
       const { data, error } = await getCategoriesSummary({
         query: { month, currency },


### PR DESCRIPTION
## Why

Two user-reported bugs in the Categories flow:

1. **Stale dashboard after editing a category limit.** The dashboard's "Expenses by category" section is powered by `useCategoriesSummary`, which caches under `['categories-summary', month, currency]`. The category mutations only invalidated the `['categories']` cache — the summary stayed stale until the user reloaded.
2. **Cannot set a zero monthly budget.** Typing `0` was silently swallowed: `AmountInput` cleared the field on `numericValue === 0`, and `CategoriesPage`'s `inputToMinorUnits` coerced `0` to `null` (treating it as "no budget"). The contract permits `monthlyBudget = 0` — already verified by the API integration test `should_ReturnZeroBudget_When_BudgetIsZero`.

## What changed

- **`src/hooks/useCategoriesSummary.ts`** — export `CATEGORIES_SUMMARY_KEYS` so other hooks can target the cache
- **`src/hooks/useCategories.ts`** — `useCreateCategory`, `useUpdateCategory`, and `useDeleteCategory` now also invalidate `CATEGORIES_SUMMARY_KEYS.all` on success/settled. Dashboard refreshes immediately after any category edit.
- **`src/components/ui/amount-input.tsx`** — new opt-in `allowZero` prop; default `false` keeps the existing behaviour for transaction amounts and amount filters where the API enforces `minimum: 1`
- **`src/components/categories/CategoryForm.tsx`** — passes `allowZero` to the budget input
- **`src/components/categories/CategoriesPage.tsx`** — `inputToMinorUnits` only rejects negative values; `0` round-trips correctly
- **`src/components/dashboard/DashboardPage.tsx`** — recognises `monthlyBudget === 0` as a real budget rather than "no budget", with a safe `pct` calculation that avoids division by zero
- **Tests** — added regression coverage for both bugs (`amount-input.test.tsx`, `useCategories.test.ts`)

## Acceptance criteria

- ✅ User can save a category with `monthlyBudget = 0`
- ✅ Dashboard category list refreshes after creating, editing, or deleting a category — including the limit field
- ✅ Existing behaviours preserved: transaction amounts and filters still reject `0` (no `allowZero` set there)
- ✅ All 205 vitest tests pass; lint + type-check clean

## How to verify

```bash
pnpm install
pnpm lint
pnpm type-check
pnpm test
pnpm dev
```

Manual smoke:
- [ ] Create a category with budget `0.00` → saved, appears in the list
- [ ] Edit a category, change its budget → dashboard "Expenses by category" updates without a reload
- [ ] Delete a category → dashboard updates without a reload
- [ ] Transaction Amount field still refuses `0` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)