### PR TITLE
feat: show clock icon on future-dated transactions

### DIFF
--- a/src/components/dashboard/RecentTransactionsCard.tsx
+++ b/src/components/dashboard/RecentTransactionsCard.tsx
@@ -48,7 +48,12 @@ export function RecentTransactionsCard({
                 >
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-medium">{t.description ?? '—'}</p>
-                    <p className="text-xs text-muted-foreground">{fmtDate(t.date)}</p>
+                    <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                      {t.date > new Date().toISOString().slice(0, 10) && (
+                        <Clock className="size-3 shrink-0" aria-label="Future-dated transaction" />
+                      )}
+                      {fmtDate(t.date)}
+                    </p>
                   </div>
                   <TransactionAmount amount={t.amount} currency={t.currency} type={t.type} />
                 </ListItem>

--- a/src/components/transactions/TransactionRow.tsx
+++ b/src/components/transactions/TransactionRow.tsx
@@ -1,4 +1,5 @@
 import type { Transaction } from '@budget-buddy-org/budget-buddy-contracts';
+import { Clock } from 'lucide-react';
 import { memo } from 'react';
 import { TransactionAmount } from '@/components/transactions/TransactionAmount';
 import { ListItem } from '@/components/ui/list-item';
@@ -9,11 +10,17 @@ interface TransactionRowProps {
   onEdit?: (id: string) => void;
 }
 
+function isFutureDated(date: string): boolean {
+  return date > new Date().toISOString().slice(0, 10);
+}
+
 export const TransactionRow = memo(function TransactionRow({
   transaction: t,
   categoryName,
   onEdit,
 }: TransactionRowProps) {
+  const future = isFutureDated(t.date);
+
   return (
     <ListItem
       onClick={() => onEdit?.(t.id)}
@@ -21,7 +28,10 @@ export const TransactionRow = memo(function TransactionRow({
     >
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium">{t.description ?? '—'}</p>
-        <p className="text-xs text-muted-foreground">{categoryName || 'No Category'}</p>
+        <p className="flex items-center gap-1 text-xs text-muted-foreground">
+          {future && <Clock className="size-3 shrink-0" aria-label="Future-dated transaction" />}
+          {categoryName || 'No Category'}
+        </p>
       </div>
       <TransactionAmount amount={t.amount} currency={t.currency} type={t.type} />
     </ListItem>


### PR DESCRIPTION
## What changed

Adds a small `Clock` icon in the subtitle/metadata line of transaction rows when a transaction's date is after today. Covers both the main transactions list and the dashboard's recent transactions card.

## Why

Future-dated transactions (scheduled entries) were visually indistinguishable from past ones. The clock indicator gives the user an at-a-glance signal without cluttering the amount column.

## Design decision

The icon lives in the secondary line (next to category name / date) rather than beside the amount. This keeps size and optical alignment natural — the `size-3` icon sits flush with the surrounding `text-xs` text — and leaves the primary data column untouched.

Color inherits `text-muted-foreground` from the parent `<p>`, matching the metadata tone.

## Reviewer notes

- `isFutureDated` is a plain string comparison (`date > today`) — safe because both sides are `YYYY-MM-DD` ISO strings.
- No new dependencies; `Clock` was already imported in `RecentTransactionsCard` for the section header.
- Type-check passes, existing tests pass.