### PR TITLE
feat: add pulse animation to sparkline end dot

### DIFF
--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -53,12 +53,19 @@ export function Sparkline({
   const area = `${path} L${points[points.length - 1][0].toFixed(2)} ${HEIGHT - PADDING} L${points[0][0].toFixed(2)} ${HEIGHT - PADDING} Z`;
   const stroke = VARIANT_STROKE[variant];
   const last = points[points.length - 1];
+  const dotLeft = `${(last[0] / WIDTH) * 100}%`;
+  const dotTop = `${(last[1] / HEIGHT) * 100}%`;
 
   // The SVG uses preserveAspectRatio="none" so the path stretches to fill the
   // container width. An SVG <circle> would distort into an ellipse under that
   // stretch (the path strokes escape via vectorEffect="non-scaling-stroke",
   // which doesn't apply to <circle>). Render the end dot as an HTML element
   // positioned in percentages so it stays a true circle at any width.
+  //
+  // The dot anchor is a zero-size element placed at the chart's last point.
+  // Both the pulse ring and the static dot center themselves on that anchor
+  // independently, so the pulse animation (which uses the standalone CSS
+  // `scale` property) cannot clobber the -translate-x/y positioning.
   return (
     <div className={cn('relative h-6 w-full', className)}>
       <svg
@@ -81,13 +88,18 @@ export function Sparkline({
       </svg>
       <span
         aria-hidden
-        className="pointer-events-none absolute size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full"
-        style={{
-          left: `${(last[0] / WIDTH) * 100}%`,
-          top: `${(last[1] / HEIGHT) * 100}%`,
-          backgroundColor: stroke,
-        }}
-      />
+        className="pointer-events-none absolute"
+        style={{ left: dotLeft, top: dotTop }}
+      >
+        <span
+          className="absolute -translate-x-1/2 -translate-y-1/2 size-3 rounded-full motion-safe:animate-dot-pulse"
+          style={{ backgroundColor: stroke }}
+        />
+        <span
+          className="absolute -translate-x-1/2 -translate-y-1/2 size-1.5 rounded-full"
+          style={{ backgroundColor: stroke }}
+        />
+      </span>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,7 @@
   --animate-fade-out: fade-out 260ms ease-in both;
   --animate-in-bottom-sheet: sheet-enter 420ms var(--easing-spring) both;
   --animate-out-bottom-sheet: sheet-exit 260ms cubic-bezier(0.4, 0, 0.8, 1) both;
+  --animate-dot-pulse: dot-pulse 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
 }
 
 .dark {
@@ -139,6 +140,11 @@ textarea {
 @keyframes fade-in {
   from { opacity: 0; }
   to { opacity: 1; }
+}
+
+@keyframes dot-pulse {
+  0% { scale: 1; opacity: 0.5; }
+  100% { scale: 2.5; opacity: 0; }
 }
 
 @keyframes fade-out {


### PR DESCRIPTION
## Summary

- Adds a pulsing ring behind the terminal dot on all three sparkline charts (Balance, Income, Expenses) on the dashboard
- The ring expands from `scale(1)` to `scale(2.5)` while fading out over 1.8 s, looping continuously
- Uses the standalone CSS `scale` property in the keyframe — avoids overwriting the `transform` used for `-translate-x/y` centering (which would have caused the dot to jump off-position on each animation frame)
- Wrapped in `motion-safe:` so the animation is suppressed for users with `prefers-reduced-motion: reduce`

## Changes

**`src/index.css`**
- Added `--animate-dot-pulse` token to `@theme` (Tailwind v4 auto-generates the `animate-dot-pulse` utility from this)
- Added `@keyframes dot-pulse` using the standalone `scale` CSS property

**`src/components/ui/sparkline.tsx`**
- Refactored the dot element: single self-closing `<span>` replaced by a zero-size anchor wrapper containing a pulse ring child and a static dot child — both center on the anchor independently via their own `-translate-x/y`
- Extracted `dotLeft`/`dotTop` variables to avoid repeating the percentage calculation

## Test plan

- [ ] Navigate to the Dashboard — all three sparkline charts should show a pulsing ring on the last data point, colour-matched to each variant (income green, expense red, balance primary)
- [ ] Enable `prefers-reduced-motion: reduce` in OS/browser accessibility settings — pulse ring should not animate
- [ ] Verify static dot is still visible and correctly positioned at the line's last point in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)