### PR TITLE
fix: prevent Edit Category dialog from flashing on close

### DIFF
--- a/src/components/categories/CategoriesPage.tsx
+++ b/src/components/categories/CategoriesPage.tsx
@@ -1,7 +1,7 @@
 import type { Category } from '@budget-buddy-org/budget-buddy-contracts';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import type React from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { CategoryForm } from '@/components/categories/CategoryForm';
 import { CategoryRow } from '@/components/categories/CategoryRow';
 import { EditCategoryDialogBody } from '@/components/categories/EditCategoryDialogBody';
@@ -27,6 +27,7 @@ import {
   useCreateCategory,
   useDeleteCategory,
 } from '@/hooks/useCategories';
+import { useLatchedValue } from '@/hooks/useLatchedValue';
 import { getApiError } from '@/lib/api-error';
 import { inputToMinorUnits } from '@/lib/category-budget';
 
@@ -35,6 +36,14 @@ export function CategoriesPage() {
   const navigate = useNavigate();
   const editId = search.edit ?? '';
   const { data: editTarget, isLoading: isEditLoading } = useCategory(editId);
+  const isEditDialogOpen = !!editId;
+  const editRender = useLatchedValue(
+    useMemo(
+      () => ({ category: editTarget, isLoading: isEditLoading }),
+      [editTarget, isEditLoading],
+    ),
+    isEditDialogOpen,
+  );
 
   const [page, setPage] = useState(0);
   const { data, isLoading } = useCategories(CATEGORIES_PAGE_SIZE, page);
@@ -183,7 +192,7 @@ export function CategoriesPage() {
       </Dialog>
 
       <Dialog
-        open={!!editId}
+        open={isEditDialogOpen}
         onOpenChange={(open) => {
           if (!open) closeEdit();
         }}
@@ -193,7 +202,7 @@ export function CategoriesPage() {
             <DialogTitle>Edit Category</DialogTitle>
             <DialogDescription>Modify the name and budget of your category</DialogDescription>
           </DialogHeader>
-          {isEditLoading ? (
+          {editRender.isLoading ? (
             <div className="space-y-6 py-4">
               <div className="space-y-2">
                 <Skeleton className="h-4 w-12" />
@@ -210,12 +219,12 @@ export function CategoriesPage() {
               </div>
             </div>
           ) : (
-            editTarget && (
+            editRender.category && (
               <EditCategoryDialogBody
-                key={editTarget.id}
-                category={editTarget}
+                key={editRender.category.id}
+                category={editRender.category}
                 onClose={closeEdit}
-                onDelete={() => handleDeleteCategory(editTarget)}
+                onDelete={() => editRender.category && handleDeleteCategory(editRender.category)}
                 isDeleting={deleteCategory.isPending}
               />
             )


### PR DESCRIPTION
## Why

Closing the Edit Category dialog produced a brief visual flash where the dialog body disappeared before the close animation finished. The Transactions page already solved this with the `useLatchedValue` hook; the Categories page hadn't adopted the pattern yet.

## What changed

- `src/components/categories/CategoriesPage.tsx` — latch `{ category, isLoading }` via `useLatchedValue(..., isEditDialogOpen)` so `EditCategoryDialogBody` stays mounted with its prior props until the dialog finishes its close animation.

The root cause: closing the dialog clears the `edit` URL search param synchronously, which makes `useCategory('')` drop the cached category. With the body gated on `editTarget && (...)`, it unmounted instantly while the dialog shell was still animating — the dialog visibly shrank to just its header for a frame.

## How to verify

- `pnpm dev`, open Categories, click a row → Edit dialog opens normally.
- Close via X, Cancel, Esc, and overlay click → in every case the body stays put as the dialog animates closed (no shrink/flash).
- Edit + save → toast appears, dialog closes smoothly.
- Delete via confirmation → toast appears, dialog closes smoothly.
- Compare side-by-side with the Transactions edit dialog — behavior matches.
- `pnpm lint` and `pnpm type-check` clean.