### PR TITLE
fix(docker): copy pnpm-workspace.yaml into deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /app
 
 # Copy registry config and lockfile first so the cache layer below is only
 # invalidated when these two files change.
-COPY .npmrc package.json pnpm-lock.yaml ./
+COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # 1. Mount the GitHub token as a BuildKit secret (never stored in any layer).
 # 2. Mount the pnpm content-addressable store as a persistent cache so that


### PR DESCRIPTION
## Why

The release pipeline's Docker build is failing on `main` with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
Cannot proceed with the frozen installation. The current "overrides"
configuration doesn't match the value found in the lockfile
```

Failing run: https://github.com/budget-buddy-org/budget-buddy-web-app/actions/runs/26100076277

## What changed

- `Dockerfile` — the deps stage now copies `pnpm-workspace.yaml` alongside `package.json` and `pnpm-lock.yaml`.

The `serialize-javascript` security override added in e4eeb60 lives in `pnpm-workspace.yaml` (pnpm 10+ moved `overrides` out of `package.json` into the workspace file). The lockfile records the override, but the Docker deps stage was never updated to copy the workspace file, so pnpm inside the container saw zero overrides while the lockfile claimed one — `--frozen-lockfile` correctly refused to proceed.

Local `pnpm install --frozen-lockfile` works because the workspace file is present; only the Docker build was blind to it.

## How to verify

- CI: the `build` job that previously errored at `pnpm install --frozen-lockfile --offline` should now resolve and continue to `pnpm build`.
- Locally (optional): `docker buildx build --secret id=github_token,env=GITHUB_TOKEN -t bb-web .` should reach the builder stage without the lockfile mismatch error.

## Notes

When the upstream `vite-plugin-pwa` / `workbox-build` chain drops its dependency on vulnerable `serialize-javascript` versions, the override (and the matching workspace entry) can be removed, but no Dockerfile change will be needed at that time — the COPY is now correct either way.