### PR TITLE
fix: Smooth out transaction search and fix iOS dialog flicker

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -17,7 +17,10 @@ function DialogOverlay({
     <DialogPrimitives.Overlay
       ref={ref}
       className={cn(
-        'fixed inset-0 z-overlay bg-black/60 backdrop-blur-sm data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
+        // transform-gpu + will-change isolate backdrop-blur into its own
+        // composite layer — iOS Safari otherwise flashes the layer on the
+        // last frame of fade-out.
+        'fixed inset-0 z-overlay bg-black/60 backdrop-blur-sm transform-gpu [will-change:opacity] data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
         className,
       )}
       {...props}
@@ -42,8 +45,12 @@ function DialogContent({
         ref={ref}
         className={cn(
           'fixed z-overlay grid w-full gap-4 border bg-background shadow-overlay',
-          // Mobile: Bottom Sheet
-          'bottom-0 left-0 max-w-none rounded-t-lg border-x-0 border-b-0 translate-y-0 max-h-[90dvh] overflow-y-auto',
+          // Mobile: Bottom Sheet. will-change:transform promotes the sheet
+          // to its own composite layer so iOS Safari doesn't flash the
+          // baseline transform for a frame before unmount. No baseline
+          // translate utility — sheet-enter/exit keyframes own `transform`
+          // with animation-fill-mode: both.
+          'bottom-0 left-0 max-w-none rounded-t-lg border-x-0 border-b-0 max-h-[90dvh] overflow-y-auto [will-change:transform]',
           'p-6',
           'data-[state=open]:animate-in-bottom-sheet data-[state=closed]:animate-out-bottom-sheet',
           // Desktop: Centered Dialog

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -98,6 +98,10 @@ export const infiniteTransactionsQueryOptions = (filters: TransactionFilters = {
       if ((page + 1) * size >= total) return undefined;
       return page + 1;
     },
+    // Keep the previous result rendered while a new filter combination
+    // fetches, so changing filters (notably the debounced search query)
+    // doesn't flash the list skeleton.
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -92,10 +92,10 @@
     0.937 38.1%, 0.968 41.1%, 1.022 50.9%, 1.003 60.1%, 1
   );
 
-  --animate-fade-in: fade-in 200ms ease-out both;
-  --animate-fade-out: fade-out 260ms ease-in both;
-  --animate-in-bottom-sheet: sheet-enter 420ms var(--easing-spring) both;
-  --animate-out-bottom-sheet: sheet-exit 260ms cubic-bezier(0.4, 0, 0.8, 1) both;
+  --animate-fade-in: fade-in 150ms ease-out both;
+  --animate-fade-out: fade-out 180ms ease-in both;
+  --animate-in-bottom-sheet: sheet-enter 320ms var(--easing-spring) both;
+  --animate-out-bottom-sheet: sheet-exit 200ms cubic-bezier(0.4, 0, 0.8, 1) both;
   --animate-dot-pulse: dot-pulse 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
 }
 
@@ -219,10 +219,10 @@ textarea {
 
 /* View Transitions for route changes — tuned to the app's fade tempo.
    The browser default is a 250ms linear cross-fade; matching --animate-fade-in
-   (200ms ease-out) keeps it consistent with dialog/popover fade ins. */
+   (150ms ease-out) keeps it consistent with dialog/popover fade ins. */
 ::view-transition-old(root),
 ::view-transition-new(root) {
-  animation-duration: 200ms;
+  animation-duration: 150ms;
   animation-timing-function: ease-out;
 }
 

--- a/src/routes/_app/transactions/index.tsx
+++ b/src/routes/_app/transactions/index.tsx
@@ -37,13 +37,15 @@ export const Route = createFileRoute('/_app/transactions/')({
     amountMax: validAmount(search.amountMax),
     edit: typeof search.edit === 'string' && search.edit.length > 0 ? search.edit : undefined,
   }),
+  // `query` is intentionally excluded — including it would re-run the loader
+  // on every debounced keystroke, swapping in `pendingComponent` and blurring
+  // the search input. The in-component query handles the filtered fetch.
   loaderDeps: ({ search }) => ({
     categoryId: search.categoryId,
     start: search.start,
     end: search.end,
     sort: search.sort,
     type: search.type,
-    query: search.query,
     amountMin: search.amountMin,
     amountMax: search.amountMax,
   }),
@@ -57,7 +59,6 @@ export const Route = createFileRoute('/_app/transactions/')({
           start: deps.start || undefined,
           end: deps.end || undefined,
           type: deps.type || undefined,
-          query: deps.query || undefined,
           amountMin: deps.amountMin,
           amountMax: deps.amountMax,
         }),


### PR DESCRIPTION
## Why

Two UX bugs on the transactions / categories pages, plus a small global polish:

1. **Transaction search felt jarring** — pausing while typing in the search box caused the whole page to flash a skeleton and the input to lose focus, so users had to tap back in to keep typing.
2. **Dialogs blinked on iOS** — closing the edit-transaction or edit-category dialog on iOS Safari briefly re-showed the dialog before it disappeared.
3. **Animations felt a touch sluggish** — tightened the global durations so dialogs and route transitions feel snappier.

## What changed

- **Stop the route loader from re-running on every keystroke.** In `src/routes/_app/transactions/index.tsx`, drop `query` from `loaderDeps` (and the loader call). The route loader still prefetches the unfiltered list for cold loads; the in-component `useInfiniteTransactions` owns the text-filtered fetch. This is what prevented `pendingComponent: TransactionsSkeleton` from swapping the page out (and unmounting the input) on each debounce.
- **Keep previous data during refetch.** In `src/hooks/useTransactions.ts`, add `placeholderData: keepPreviousData` to `infiniteTransactionsQueryOptions` so the list keeps rendering previous results while the new filter combination loads — `isLoading` stays `false` and the inner skeleton no longer flashes. Mirrors the pattern already in `transactionsQueryOptions`.
- **Fix the iOS dialog close flicker.** In `src/components/ui/dialog.tsx`:
  - Overlay: add `transform-gpu` + `[will-change:opacity]` so Safari composites the backdrop-blur on its own stable layer and doesn't flush an extra full-opacity frame after `data-state=\"closed\"`.
  - Content: add `[will-change:transform]` and remove the redundant `translate-y-0` baseline (the `sheet-enter`/`sheet-exit` keyframes own `transform` with `animation-fill-mode: both`), so Safari doesn't snap the sheet back to its open position for one frame before unmount.
- **Tighten animation tokens** in `src/index.css`: fade-in 200→150ms, fade-out 260→180ms, sheet-enter 420→320ms, sheet-exit 260→200ms, view-transition root 200→150ms. Reduced-motion media query untouched.

## How to verify

1. `pnpm install && pnpm type-check && pnpm lint && pnpm test` — clean (265 tests pass).
2. `pnpm dev` → `/transactions`:
   - Type slowly into the search box. Input must stay focused; results refresh in place; no full-page skeleton.
   - Clear the search the same way. Same expectation.
   - Cold-load `/transactions?query=coffee`: the inner list skeleton may briefly show during the component-level fetch — acceptable.
3. iOS Safari (real device or Simulator):
   - Open the edit-transaction dialog, close it. Should slide down once with no blink-back.
   - Repeat for Add Transaction and Edit Category dialogs.
   - Toggle iOS reduced-motion → dialogs should still close cleanly.
4. Desktop sanity check: dialog fades and the bottom-sheet on mobile both feel snappier but not abrupt.

## Notes

- Animation tweaks are visual only; nothing else depends on the precise durations except the view-transition comment, which is updated in sync.
- The `will-change` hints are scoped to the overlay/content and only matter while the dialog is mounted — Radix unmounts when closed, so there's no idle memory cost.