### PR TITLE
feat(settings): sync app settings and add account/data deletion

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,8 +1,12 @@
 import { Outlet } from '@tanstack/react-router';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { AppShell } from '@/components/layout/AppShell';
+import { useSettingsSync } from '@/hooks/useSettingsSync';
 
 export function AppLayout() {
+  // Syncs appearance + preference settings with the server while authenticated.
+  useSettingsSync();
+
   return (
     <AppShell>
       <ErrorBoundary>

--- a/src/components/settings/DangerZoneSection.test.tsx
+++ b/src/components/settings/DangerZoneSection.test.tsx
@@ -1,0 +1,143 @@
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@/test/utils';
+import { DangerZoneSection } from './DangerZoneSection';
+
+vi.mock('@/hooks/useUserAccount', () => ({
+  useClearUserData: vi.fn(),
+  useDeleteAccount: vi.fn(),
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: vi.fn() }));
+vi.mock('react-oidc-context', () => ({ useAuth: vi.fn() }));
+
+const { useClearUserData, useDeleteAccount } = await import('@/hooks/useUserAccount');
+const { useToast } = await import('@/hooks/use-toast');
+const { useAuth } = await import('react-oidc-context');
+
+type MutateOpts = { onSuccess?: () => unknown; onError?: () => unknown };
+
+const toast = vi.fn();
+const removeUser = vi.fn().mockResolvedValue(undefined);
+const signoutRedirect = vi.fn().mockResolvedValue(undefined);
+
+// A mutate stub that synchronously invokes the success or error callback the
+// component passes, mimicking a resolved/rejected mutation.
+function settledMutate(outcome: 'success' | 'error') {
+  return vi.fn((_vars: unknown, opts?: MutateOpts) => {
+    if (outcome === 'success') return opts?.onSuccess?.();
+    return opts?.onError?.();
+  });
+}
+
+function setup({
+  clearMutate = settledMutate('success'),
+  deleteMutate = settledMutate('success'),
+}: {
+  clearMutate?: ReturnType<typeof settledMutate>;
+  deleteMutate?: ReturnType<typeof settledMutate>;
+} = {}) {
+  vi.mocked(useClearUserData).mockReturnValue({
+    mutate: clearMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof useClearUserData>);
+  vi.mocked(useDeleteAccount).mockReturnValue({
+    mutate: deleteMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof useDeleteAccount>);
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const clearCacheSpy = vi.spyOn(queryClient, 'clear');
+  render(<DangerZoneSection />, { queryClient });
+  return { clearMutate, deleteMutate, clearCacheSpy };
+}
+
+// Open one of the two confirmation dialogs by clicking its section trigger,
+// then return the dialog element so queries can be scoped inside it (the
+// "Delete account" label appears on both the trigger and the confirm button).
+async function openDialog(triggerName: RegExp) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: triggerName }));
+  const dialog = await screen.findByRole('dialog');
+  return { user, dialog };
+}
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useToast).mockReturnValue({ toast } as unknown as ReturnType<typeof useToast>);
+  vi.mocked(useAuth).mockReturnValue({
+    removeUser,
+    signoutRedirect,
+  } as unknown as ReturnType<typeof useAuth>);
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { href: '/', pathname: '/', search: '' },
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+});
+
+describe('DangerZoneSection — clear data', () => {
+  it('clears data and shows a success toast on confirm', async () => {
+    const { clearMutate } = setup();
+    const { user, dialog } = await openDialog(/clear all data/i);
+
+    await user.click(within(dialog).getByRole('button', { name: /clear data/i }));
+
+    expect(clearMutate).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ variant: 'success' }));
+  });
+
+  it('shows a destructive toast and keeps the dialog open on failure', async () => {
+    const { clearMutate } = setup({ clearMutate: settledMutate('error') });
+    const { user, dialog } = await openDialog(/clear all data/i);
+
+    await user.click(within(dialog).getByRole('button', { name: /clear data/i }));
+
+    expect(clearMutate).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ variant: 'destructive' }));
+    // Dialog stays mounted so the user can retry.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+describe('DangerZoneSection — delete account', () => {
+  it('clears the cache and signs the user out on success', async () => {
+    const { clearCacheSpy } = setup();
+    const { user, dialog } = await openDialog(/delete account/i);
+
+    await user.click(within(dialog).getByRole('button', { name: /delete account/i }));
+
+    await waitFor(() => expect(signoutRedirect).toHaveBeenCalledTimes(1));
+    expect(clearCacheSpy).toHaveBeenCalledTimes(1);
+    // The normal sign-out path does not hit the local-credential fallback.
+    expect(removeUser).not.toHaveBeenCalled();
+  });
+
+  it('falls back to clearing local credentials when sign-out is rejected', async () => {
+    signoutRedirect.mockRejectedValueOnce(new Error('account gone'));
+    setup();
+    const { user, dialog } = await openDialog(/delete account/i);
+
+    await user.click(within(dialog).getByRole('button', { name: /delete account/i }));
+
+    await waitFor(() => expect(removeUser).toHaveBeenCalledTimes(1));
+    expect(window.location.href).toBe('/');
+  });
+
+  it('shows a destructive toast and keeps the dialog open on failure', async () => {
+    setup({ deleteMutate: settledMutate('error') });
+    const { user, dialog } = await openDialog(/delete account/i);
+
+    await user.click(within(dialog).getByRole('button', { name: /delete account/i }));
+
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ variant: 'destructive' }));
+    expect(signoutRedirect).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/DangerZoneSection.tsx
+++ b/src/components/settings/DangerZoneSection.tsx
@@ -1,0 +1,118 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, Eraser, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useAuth } from 'react-oidc-context';
+import { ConfirmationDialog } from '@/components/ConfirmationDialog';
+import { Button } from '@/components/ui/button';
+import { Section } from '@/components/ui/section';
+import { useToast } from '@/hooks/use-toast';
+import { useClearUserData, useDeleteAccount } from '@/hooks/useUserAccount';
+
+export function DangerZoneSection() {
+  const { toast } = useToast();
+  const { removeUser, signoutRedirect } = useAuth();
+  const queryClient = useQueryClient();
+
+  const clearData = useClearUserData();
+  const deleteAccount = useDeleteAccount();
+
+  const [clearOpen, setClearOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const handleClearData = () => {
+    clearData.mutate(undefined, {
+      onSuccess: () => {
+        setClearOpen(false);
+        toast({ title: 'All financial data cleared', variant: 'success' });
+      },
+      onError: () => {
+        toast({ title: "Couldn't clear your data", variant: 'destructive' });
+      },
+    });
+  };
+
+  const handleDeleteAccount = () => {
+    deleteAccount.mutate(undefined, {
+      onSuccess: async () => {
+        // The account is gone at the identity provider; drop all cached server
+        // state and local credentials, then end the session.
+        queryClient.clear();
+        try {
+          await signoutRedirect();
+        } catch {
+          // The IdP end-session may reject a deleted account — clear the local
+          // session and reload so the app falls back to the sign-in flow.
+          await removeUser();
+          window.location.href = '/';
+        }
+      },
+      onError: () => {
+        setDeleteOpen(false);
+        toast({
+          title: "Couldn't delete your account",
+          description: 'Please try again in a moment.',
+          variant: 'destructive',
+        });
+      },
+    });
+  };
+
+  return (
+    <Section
+      title="Danger Zone"
+      icon={AlertTriangle}
+      cardClassName="p-4 space-y-4 border-destructive/40"
+    >
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium">Clear all data</p>
+        <p className="text-xs text-muted-foreground">
+          Permanently delete every category and transaction. Your account and settings stay intact.
+        </p>
+      </div>
+      <Button
+        variant="outline"
+        className="w-full cursor-pointer text-destructive hover:bg-destructive/10 hover:text-destructive sm:w-auto"
+        onClick={() => setClearOpen(true)}
+      >
+        <Eraser className="size-4" />
+        Clear all data
+      </Button>
+
+      <div className="flex flex-col gap-1 border-t border-border pt-4">
+        <p className="text-sm font-medium">Delete account</p>
+        <p className="text-xs text-muted-foreground">
+          Permanently delete your account and all associated data. This cannot be undone.
+        </p>
+      </div>
+      <Button
+        variant="destructive"
+        className="w-full cursor-pointer sm:w-auto"
+        onClick={() => setDeleteOpen(true)}
+      >
+        <Trash2 className="size-4" />
+        Delete account
+      </Button>
+
+      <ConfirmationDialog
+        isOpen={clearOpen}
+        onOpenChange={setClearOpen}
+        onConfirm={handleClearData}
+        title="Clear all data?"
+        description="This permanently deletes all your categories and transactions. Your account and settings are kept. This action cannot be undone."
+        confirmText="Clear data"
+        variant="destructive"
+        isLoading={clearData.isPending}
+      />
+      <ConfirmationDialog
+        isOpen={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onConfirm={handleDeleteAccount}
+        title="Delete your account?"
+        description="This permanently deletes your account and all associated data, and signs you out. This action cannot be undone."
+        confirmText="Delete account"
+        variant="destructive"
+        isLoading={deleteAccount.isPending}
+      />
+    </Section>
+  );
+}

--- a/src/components/settings/DangerZoneSection.tsx
+++ b/src/components/settings/DangerZoneSection.tsx
@@ -47,7 +47,7 @@ export function DangerZoneSection() {
         }
       },
       onError: () => {
-        setDeleteOpen(false);
+        // Leave the dialog open so the user can retry, matching the clear flow.
         toast({
           title: "Couldn't delete your account",
           description: 'Please try again in a moment.',

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { PageHeader } from '@/components/layout/PageHeader';
 import { AccountSection } from '@/components/settings/AccountSection';
+import { DangerZoneSection } from '@/components/settings/DangerZoneSection';
 import { FontSizeSection } from '@/components/settings/FontSizeSection';
 import { InterfaceSection } from '@/components/settings/InterfaceSection';
 import { PreferencesSection } from '@/components/settings/PreferencesSection';
@@ -20,6 +21,7 @@ export function SettingsPage() {
         <FontSizeSection />
         <InterfaceSection />
         <VersionSection />
+        <DangerZoneSection />
       </div>
     </PageContainer>
   );

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -11,7 +11,7 @@ import { CATEGORIES_SUMMARY_KEYS } from '@/hooks/useCategoriesSummary';
 
 export const CATEGORIES_PAGE_SIZE = 200;
 
-const KEYS = {
+export const CATEGORIES_KEYS = {
   all: ['categories'] as const,
   list: (size: number, page: number) => ['categories', 'list', size, page] as const,
   detail: (id: string) => ['categories', id] as const,
@@ -19,7 +19,7 @@ const KEYS = {
 
 export const categoriesQueryOptions = (size = CATEGORIES_PAGE_SIZE, page = 0) =>
   queryOptions({
-    queryKey: KEYS.list(size, page),
+    queryKey: CATEGORIES_KEYS.list(size, page),
     queryFn: async () => {
       const { data, error } = await listCategories({
         query: { size, page },
@@ -35,7 +35,7 @@ export function useCategories(size = CATEGORIES_PAGE_SIZE, page = 0) {
 
 export const categoryDetailQueryOptions = (id: string) =>
   queryOptions({
-    queryKey: KEYS.detail(id),
+    queryKey: CATEGORIES_KEYS.detail(id),
     queryFn: async () => {
       const { data, error } = await getCategory({
         path: { categoryId: id },
@@ -61,7 +61,7 @@ export function useCreateCategory() {
       return data;
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: KEYS.all });
+      qc.invalidateQueries({ queryKey: CATEGORIES_KEYS.all });
       qc.invalidateQueries({ queryKey: CATEGORIES_SUMMARY_KEYS.all });
     },
   });
@@ -79,8 +79,8 @@ export function useUpdateCategory(id: string) {
       return data;
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: KEYS.all });
-      qc.invalidateQueries({ queryKey: KEYS.detail(id) });
+      qc.invalidateQueries({ queryKey: CATEGORIES_KEYS.all });
+      qc.invalidateQueries({ queryKey: CATEGORIES_KEYS.detail(id) });
       qc.invalidateQueries({ queryKey: CATEGORIES_SUMMARY_KEYS.all });
     },
   });
@@ -97,8 +97,8 @@ export function useDeleteCategory() {
       return id;
     },
     onMutate: async (id) => {
-      await qc.cancelQueries({ queryKey: KEYS.all });
-      const previous = qc.getQueriesData<PaginatedCategories>({ queryKey: KEYS.all });
+      await qc.cancelQueries({ queryKey: CATEGORIES_KEYS.all });
+      const previous = qc.getQueriesData<PaginatedCategories>({ queryKey: CATEGORIES_KEYS.all });
 
       // Optimistically update all paginated lists
       qc.setQueriesData<PaginatedCategories>({ queryKey: ['categories', 'list'] }, (old) =>
@@ -116,10 +116,10 @@ export function useDeleteCategory() {
     },
     onSuccess: (_data, id) => {
       // Also remove the specific detail query if it exists
-      qc.removeQueries({ queryKey: KEYS.detail(id) });
+      qc.removeQueries({ queryKey: CATEGORIES_KEYS.detail(id) });
     },
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: KEYS.all });
+      qc.invalidateQueries({ queryKey: CATEGORIES_KEYS.all });
       qc.invalidateQueries({ queryKey: CATEGORIES_SUMMARY_KEYS.all });
     },
   });

--- a/src/hooks/useSettingsSync.test.ts
+++ b/src/hooks/useSettingsSync.test.ts
@@ -1,0 +1,123 @@
+import {
+  getCurrentUserClientSettings,
+  upsertCurrentUserClientSettings,
+} from '@budget-buddy-org/budget-buddy-contracts';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { collectWebSettings } from '@/lib/clientSettings';
+import { useThemeStore } from '@/stores/theme.store';
+import { useUserPreferencesStore } from '@/stores/user-preferences.store';
+import { useSettingsSync } from './useSettingsSync';
+import { useUserSettings } from './useUserSettings';
+
+type GetResult = Awaited<ReturnType<typeof getCurrentUserClientSettings>>;
+type UpsertResult = Awaited<ReturnType<typeof upsertCurrentUserClientSettings>>;
+
+vi.mock('@budget-buddy-org/budget-buddy-contracts', () => ({
+  getCurrentUserClientSettings: vi.fn(),
+  upsertCurrentUserClientSettings: vi.fn(),
+  deleteCurrentUserClientSettings: vi.fn(),
+}));
+
+const themeDefaults = {
+  theme: 'system' as const,
+  primaryHue: 240,
+  fontSize: 16,
+  showNavLabels: true,
+  glassEffect: true,
+  showDescriptions: true,
+};
+const prefDefaults = {
+  currency: null,
+  dateFormat: 'medium' as const,
+  numberLocale: null,
+  isBalanceHidden: false,
+};
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+// Render the sync hook alongside the query so tests can await hydration.
+function useHarness() {
+  useSettingsSync();
+  return useUserSettings();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useThemeStore.setState(themeDefaults);
+  useUserPreferencesStore.setState(prefDefaults);
+});
+
+describe('useSettingsSync', () => {
+  it('pulls server settings into the stores and does not echo them back', async () => {
+    vi.mocked(getCurrentUserClientSettings).mockResolvedValue({
+      data: { clientId: 'web', settings: { theme: 'dark', primaryHue: 120 } },
+      error: undefined,
+      response: { status: 200 },
+    } as unknown as GetResult);
+
+    const { result } = renderHook(useHarness, { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(useThemeStore.getState().theme).toBe('dark'));
+    expect(useThemeStore.getState().primaryHue).toBe(120);
+    expect(result.current.isSuccess).toBe(true);
+    // The pull-induced store update must not be pushed back to the server.
+    expect(upsertCurrentUserClientSettings).not.toHaveBeenCalled();
+  });
+
+  it('seeds the server when no settings row exists yet', async () => {
+    vi.mocked(getCurrentUserClientSettings).mockResolvedValue({
+      data: undefined,
+      error: { title: 'Not Found' },
+      response: { status: 404 },
+    } as unknown as GetResult);
+    vi.mocked(upsertCurrentUserClientSettings).mockResolvedValue({
+      data: { clientId: 'web', settings: {} },
+      error: undefined,
+    } as unknown as UpsertResult);
+
+    renderHook(useHarness, { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(upsertCurrentUserClientSettings).toHaveBeenCalledTimes(1));
+    expect(upsertCurrentUserClientSettings).toHaveBeenCalledWith({
+      path: { clientId: 'web' },
+      body: { settings: expect.objectContaining({ theme: 'system', primaryHue: 240 }) },
+    });
+  });
+
+  it('pushes local changes to the server after hydration (debounced)', async () => {
+    // Server row already matches local defaults, so no seed/echo fires.
+    vi.mocked(getCurrentUserClientSettings).mockResolvedValue({
+      data: { clientId: 'web', settings: collectWebSettings() },
+      error: undefined,
+      response: { status: 200 },
+    } as unknown as GetResult);
+    vi.mocked(upsertCurrentUserClientSettings).mockResolvedValue({
+      data: { clientId: 'web', settings: {} },
+      error: undefined,
+    } as unknown as UpsertResult);
+
+    const { result } = renderHook(useHarness, { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await act(async () => {});
+
+    act(() => {
+      useThemeStore.getState().setTheme('dark');
+    });
+
+    // Wait out the 1s debounce.
+    await waitFor(() => expect(upsertCurrentUserClientSettings).toHaveBeenCalledTimes(1), {
+      timeout: 2000,
+    });
+    expect(upsertCurrentUserClientSettings).toHaveBeenCalledWith({
+      path: { clientId: 'web' },
+      body: { settings: expect.objectContaining({ theme: 'dark' }) },
+    });
+  });
+});

--- a/src/hooks/useSettingsSync.ts
+++ b/src/hooks/useSettingsSync.ts
@@ -1,0 +1,87 @@
+import type { ClientSettingsPayload } from '@budget-buddy-org/budget-buddy-contracts';
+import { useEffect, useRef } from 'react';
+import { useUpsertUserSettings, useUserSettings } from '@/hooks/useUserSettings';
+import {
+  applyWebSettings,
+  collectWebSettings,
+  parseWebSettings,
+  type WebClientSettings,
+} from '@/lib/clientSettings';
+import { useThemeStore } from '@/stores/theme.store';
+import { useUserPreferencesStore } from '@/stores/user-preferences.store';
+
+const PUSH_DEBOUNCE_MS = 1000;
+
+/** Widen the structured settings to the opaque payload the contracts expect. */
+const toPayload = (s: WebClientSettings): ClientSettingsPayload =>
+  s as unknown as ClientSettingsPayload;
+
+/**
+ * Two-way sync of the appearance + preference stores with the server's per-client
+ * settings row, so a user's customisations follow them across devices.
+ *
+ * - **Pull (once):** on the first successful fetch, server settings are merged
+ *   onto the local stores. If the server has no row yet, the current local
+ *   settings are pushed to seed it.
+ * - **Push (debounced):** subsequent local changes are written back to the
+ *   server. A snapshot of the last-synced JSON suppresses the echo from the
+ *   pull and avoids redundant writes when nothing actually changed.
+ *
+ * Mount once inside the authenticated layout. A background refetch never
+ * re-hydrates mid-session, so it can't clobber unsynced local edits.
+ */
+export function useSettingsSync() {
+  const { data, isSuccess } = useUserSettings();
+  const upsert = useUpsertUserSettings();
+
+  const hydratedRef = useRef(false);
+  const lastSyncedRef = useRef<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  // Keep a stable reference so the subscribe effect can run once on mount while
+  // always calling the latest mutation instance.
+  const upsertRef = useRef(upsert);
+  useEffect(() => {
+    upsertRef.current = upsert;
+  });
+
+  // Pull: merge server settings into local stores exactly once.
+  useEffect(() => {
+    if (!isSuccess || hydratedRef.current) return;
+    hydratedRef.current = true;
+
+    const merged = parseWebSettings(data?.settings);
+    // Record before applying so the resulting store updates are recognised as
+    // an echo of the pull, not a local change to push back.
+    lastSyncedRef.current = JSON.stringify(merged);
+    applyWebSettings(merged);
+
+    // No server row yet — seed it so other clients inherit these settings.
+    if (data === null) {
+      upsertRef.current.mutate(toPayload(merged));
+    }
+  }, [isSuccess, data]);
+
+  // Push: debounce-write local changes back to the server.
+  useEffect(() => {
+    const maybePush = () => {
+      if (!hydratedRef.current) return;
+      const current = collectWebSettings();
+      const json = JSON.stringify(current);
+      if (json === lastSyncedRef.current) return;
+
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        lastSyncedRef.current = json;
+        upsertRef.current.mutate(toPayload(current));
+      }, PUSH_DEBOUNCE_MS);
+    };
+
+    const unsubTheme = useThemeStore.subscribe(maybePush);
+    const unsubPrefs = useUserPreferencesStore.subscribe(maybePush);
+    return () => {
+      unsubTheme();
+      unsubPrefs();
+      clearTimeout(timerRef.current);
+    };
+  }, []);
+}

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -39,7 +39,7 @@ export interface TransactionFilters {
 
 export const TRANSACTIONS_PAGE_SIZE = 20;
 
-const KEYS = {
+export const TRANSACTIONS_KEYS = {
   all: ['transactions'] as const,
   lists: ['transactions', 'list'] as const,
   list: (filters: TransactionFilters) => ['transactions', 'list', filters] as const,
@@ -51,14 +51,14 @@ const KEYS = {
 // the dashboard reads from. Invalidate them together so summary cards stay in
 // sync after create/update/delete.
 function invalidateTransactionCaches(qc: QueryClient) {
-  qc.invalidateQueries({ queryKey: KEYS.all });
+  qc.invalidateQueries({ queryKey: TRANSACTIONS_KEYS.all });
   qc.invalidateQueries({ queryKey: TRANSACTIONS_SUMMARY_KEYS.all });
   qc.invalidateQueries({ queryKey: CATEGORIES_SUMMARY_KEYS.all });
 }
 
 export const transactionsQueryOptions = (filters: TransactionFilters = {}) =>
   queryOptions({
-    queryKey: KEYS.list(filters),
+    queryKey: TRANSACTIONS_KEYS.list(filters),
     queryFn: async () => {
       const { data, error } = await listTransactions({
         query: {
@@ -78,7 +78,7 @@ export function useTransactions(filters: TransactionFilters = {}) {
 
 export const infiniteTransactionsQueryOptions = (filters: TransactionFilters = {}) => {
   return infiniteQueryOptions({
-    queryKey: KEYS.infinite(filters),
+    queryKey: TRANSACTIONS_KEYS.infinite(filters),
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
       const { data, error } = await listTransactions({
@@ -110,7 +110,7 @@ export function useInfiniteTransactions(filters: TransactionFilters = {}) {
 
 export const transactionDetailQueryOptions = (id: string) =>
   queryOptions({
-    queryKey: KEYS.detail(id),
+    queryKey: TRANSACTIONS_KEYS.detail(id),
     queryFn: async () => {
       const { data, error } = await getTransaction({
         path: { transactionId: id },
@@ -155,7 +155,7 @@ export function useUpdateTransaction(id: string) {
     },
     onSuccess: () => {
       invalidateTransactionCaches(qc);
-      qc.invalidateQueries({ queryKey: KEYS.detail(id) });
+      qc.invalidateQueries({ queryKey: TRANSACTIONS_KEYS.detail(id) });
     },
   });
 }
@@ -171,12 +171,12 @@ export function useDeleteTransaction() {
       return id;
     },
     onMutate: async (id) => {
-      await qc.cancelQueries({ queryKey: KEYS.all });
-      const previous = qc.getQueriesData({ queryKey: KEYS.all });
+      await qc.cancelQueries({ queryKey: TRANSACTIONS_KEYS.all });
+      const previous = qc.getQueriesData({ queryKey: TRANSACTIONS_KEYS.all });
 
       // Optimistically update every cached list view — removing the tx by id
       // is safe regardless of the filters each list was fetched with.
-      qc.setQueriesData<PaginatedTransactions>({ queryKey: KEYS.lists }, (old) => {
+      qc.setQueriesData<PaginatedTransactions>({ queryKey: TRANSACTIONS_KEYS.lists }, (old) => {
         if (!old) return old;
         const nextItems = old.items.filter((t) => t.id !== id);
         if (nextItems.length === old.items.length) return old;
@@ -221,7 +221,7 @@ export function useDeleteTransaction() {
     },
     onSuccess: (_data, id) => {
       // Also remove the specific detail query if it exists
-      qc.removeQueries({ queryKey: KEYS.detail(id) });
+      qc.removeQueries({ queryKey: TRANSACTIONS_KEYS.detail(id) });
     },
     onSettled: () => invalidateTransactionCaches(qc),
   });

--- a/src/hooks/useUserAccount.test.ts
+++ b/src/hooks/useUserAccount.test.ts
@@ -1,0 +1,114 @@
+import {
+  clearCurrentUserData,
+  deleteCurrentUser,
+  getCurrentUser,
+} from '@budget-buddy-org/budget-buddy-contracts';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useClearUserData, useCurrentUser, useDeleteAccount } from './useUserAccount';
+
+type GetUserResult = Awaited<ReturnType<typeof getCurrentUser>>;
+type ClearResult = Awaited<ReturnType<typeof clearCurrentUserData>>;
+type DeleteResult = Awaited<ReturnType<typeof deleteCurrentUser>>;
+
+vi.mock('@budget-buddy-org/budget-buddy-contracts', () => ({
+  getCurrentUser: vi.fn(),
+  clearCurrentUserData: vi.fn(),
+  deleteCurrentUser: vi.fn(),
+}));
+
+function makeWrapper(qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })) {
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+  return { qc, wrapper };
+}
+
+describe('useCurrentUser', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches the bootstrap user record', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({
+      data: { id: 'user-1', preferences: { language: 'en', currency: 'EUR', timezone: 'UTC' } },
+      error: undefined,
+    } as unknown as GetUserResult);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useCurrentUser(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.id).toBe('user-1');
+  });
+});
+
+describe('useClearUserData', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('clears data and invalidates the financial caches', async () => {
+    vi.mocked(clearCurrentUserData).mockResolvedValue({
+      data: undefined,
+      error: undefined,
+    } as unknown as ClearResult);
+
+    const { qc, wrapper } = makeWrapper();
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+    const { result } = renderHook(() => useClearUserData(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(clearCurrentUserData).toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['transactions'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['categories'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['categories-summary'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['transactions-summary'] });
+  });
+
+  it('surfaces an error and skips invalidation on failure', async () => {
+    vi.mocked(clearCurrentUserData).mockResolvedValue({
+      data: undefined,
+      error: { title: 'Server Error' },
+    } as unknown as ClearResult);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useClearUserData(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useDeleteAccount', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls deleteCurrentUser', async () => {
+    vi.mocked(deleteCurrentUser).mockResolvedValue({
+      data: undefined,
+      error: undefined,
+    } as unknown as DeleteResult);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(deleteCurrentUser).toHaveBeenCalled();
+  });
+
+  it('errors when the delete fails', async () => {
+    vi.mocked(deleteCurrentUser).mockResolvedValue({
+      data: undefined,
+      error: { title: 'Provider unavailable' },
+    } as unknown as DeleteResult);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/hooks/useUserAccount.ts
+++ b/src/hooks/useUserAccount.ts
@@ -1,0 +1,62 @@
+import type { Me } from '@budget-buddy-org/budget-buddy-contracts';
+import {
+  clearCurrentUserData,
+  deleteCurrentUser,
+  getCurrentUser,
+} from '@budget-buddy-org/budget-buddy-contracts';
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CATEGORIES_SUMMARY_KEYS } from '@/hooks/useCategoriesSummary';
+import { TRANSACTIONS_SUMMARY_KEYS } from '@/hooks/useMonthlySummary';
+
+export const CURRENT_USER_KEYS = {
+  all: ['current-user'] as const,
+};
+
+export const currentUserQueryOptions = () =>
+  queryOptions<Me>({
+    queryKey: CURRENT_USER_KEYS.all,
+    queryFn: async () => {
+      const { data, error } = await getCurrentUser();
+      if (error) throw error;
+      return data;
+    },
+  });
+
+export function useCurrentUser() {
+  return useQuery(currentUserQueryOptions());
+}
+
+/**
+ * "Start over" — wipes the user's categories and transactions while keeping the
+ * account, preferences, and per-client settings intact. After success the
+ * financial-data caches are invalidated so the UI reflects the empty state.
+ */
+export function useClearUserData() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { error } = await clearCurrentUserData();
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['transactions'] });
+      qc.invalidateQueries({ queryKey: ['categories'] });
+      qc.invalidateQueries({ queryKey: CATEGORIES_SUMMARY_KEYS.all });
+      qc.invalidateQueries({ queryKey: TRANSACTIONS_SUMMARY_KEYS.all });
+    },
+  });
+}
+
+/**
+ * Permanently deletes the account at the identity provider and cascade-deletes
+ * all local data. The bearer token may remain valid until expiry, so callers
+ * must clear local credentials and end the session after this resolves.
+ */
+export function useDeleteAccount() {
+  return useMutation({
+    mutationFn: async () => {
+      const { error } = await deleteCurrentUser();
+      if (error) throw error;
+    },
+  });
+}

--- a/src/hooks/useUserAccount.ts
+++ b/src/hooks/useUserAccount.ts
@@ -5,8 +5,10 @@ import {
   getCurrentUser,
 } from '@budget-buddy-org/budget-buddy-contracts';
 import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CATEGORIES_KEYS } from '@/hooks/useCategories';
 import { CATEGORIES_SUMMARY_KEYS } from '@/hooks/useCategoriesSummary';
 import { TRANSACTIONS_SUMMARY_KEYS } from '@/hooks/useMonthlySummary';
+import { TRANSACTIONS_KEYS } from '@/hooks/useTransactions';
 
 export const CURRENT_USER_KEYS = {
   all: ['current-user'] as const,
@@ -39,8 +41,8 @@ export function useClearUserData() {
       if (error) throw error;
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['transactions'] });
-      qc.invalidateQueries({ queryKey: ['categories'] });
+      qc.invalidateQueries({ queryKey: TRANSACTIONS_KEYS.all });
+      qc.invalidateQueries({ queryKey: CATEGORIES_KEYS.all });
       qc.invalidateQueries({ queryKey: CATEGORIES_SUMMARY_KEYS.all });
       qc.invalidateQueries({ queryKey: TRANSACTIONS_SUMMARY_KEYS.all });
     },

--- a/src/hooks/useUserSettings.test.ts
+++ b/src/hooks/useUserSettings.test.ts
@@ -1,0 +1,122 @@
+import {
+  deleteCurrentUserClientSettings,
+  getCurrentUserClientSettings,
+  upsertCurrentUserClientSettings,
+} from '@budget-buddy-org/budget-buddy-contracts';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  USER_SETTINGS_KEYS,
+  useDeleteUserSettings,
+  useUpsertUserSettings,
+  useUserSettings,
+} from './useUserSettings';
+
+type GetResult = Awaited<ReturnType<typeof getCurrentUserClientSettings>>;
+type UpsertResult = Awaited<ReturnType<typeof upsertCurrentUserClientSettings>>;
+type DeleteResult = Awaited<ReturnType<typeof deleteCurrentUserClientSettings>>;
+
+vi.mock('@budget-buddy-org/budget-buddy-contracts', () => ({
+  getCurrentUserClientSettings: vi.fn(),
+  upsertCurrentUserClientSettings: vi.fn(),
+  deleteCurrentUserClientSettings: vi.fn(),
+}));
+
+function makeWrapper(qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })) {
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+  return { qc, wrapper };
+}
+
+describe('useUserSettings', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches the web client settings row', async () => {
+    vi.mocked(getCurrentUserClientSettings).mockResolvedValue({
+      data: { clientId: 'web', settings: { theme: 'dark' } },
+      error: undefined,
+      response: { status: 200 },
+    } as unknown as GetResult);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.settings).toEqual({ theme: 'dark' });
+    expect(getCurrentUserClientSettings).toHaveBeenCalledWith({ path: { clientId: 'web' } });
+  });
+
+  it('treats a 404 as null instead of an error', async () => {
+    vi.mocked(getCurrentUserClientSettings).mockResolvedValue({
+      data: undefined,
+      error: { title: 'Not Found' },
+      response: { status: 404 },
+    } as unknown as GetResult);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+
+  it('throws on non-404 errors', async () => {
+    vi.mocked(getCurrentUserClientSettings).mockResolvedValue({
+      data: undefined,
+      error: { title: 'Server Error' },
+      response: { status: 500 },
+    } as unknown as GetResult);
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useUpsertUserSettings', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('puts the payload and primes the cache with the response', async () => {
+    const row = { clientId: 'web', settings: { theme: 'light' } };
+    vi.mocked(upsertCurrentUserClientSettings).mockResolvedValue({
+      data: row,
+      error: undefined,
+    } as unknown as UpsertResult);
+
+    const { qc, wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUpsertUserSettings(), { wrapper });
+
+    result.current.mutate({ theme: 'light' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(upsertCurrentUserClientSettings).toHaveBeenCalledWith({
+      path: { clientId: 'web' },
+      body: { settings: { theme: 'light' } },
+    });
+    expect(qc.getQueryData(USER_SETTINGS_KEYS.detail('web'))).toEqual(row);
+  });
+});
+
+describe('useDeleteUserSettings', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes the row and clears the cache entry', async () => {
+    vi.mocked(deleteCurrentUserClientSettings).mockResolvedValue({
+      data: undefined,
+      error: undefined,
+    } as unknown as DeleteResult);
+
+    const { qc, wrapper } = makeWrapper();
+    qc.setQueryData(USER_SETTINGS_KEYS.detail('web'), { clientId: 'web', settings: {} });
+    const { result } = renderHook(() => useDeleteUserSettings(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(deleteCurrentUserClientSettings).toHaveBeenCalledWith({ path: { clientId: 'web' } });
+    expect(qc.getQueryData(USER_SETTINGS_KEYS.detail('web'))).toBeNull();
+  });
+});

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -1,0 +1,70 @@
+import type {
+  ClientSettings,
+  ClientSettingsPayload,
+} from '@budget-buddy-org/budget-buddy-contracts';
+import {
+  deleteCurrentUserClientSettings,
+  getCurrentUserClientSettings,
+  upsertCurrentUserClientSettings,
+} from '@budget-buddy-org/budget-buddy-contracts';
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { WEB_CLIENT_ID } from '@/lib/clientSettings';
+
+export const USER_SETTINGS_KEYS = {
+  all: ['user-settings'] as const,
+  detail: (clientId: string) => ['user-settings', clientId] as const,
+};
+
+/**
+ * Fetches the per-client settings row for a single client. A 404 (no settings
+ * stored yet) is treated as `null` rather than an error — a fresh account
+ * legitimately has no row until the first upsert.
+ */
+export const userSettingsQueryOptions = (clientId = WEB_CLIENT_ID) =>
+  queryOptions<ClientSettings | null>({
+    queryKey: USER_SETTINGS_KEYS.detail(clientId),
+    queryFn: async () => {
+      const { data, error, response } = await getCurrentUserClientSettings({
+        path: { clientId },
+      });
+      if (response?.status === 404) return null;
+      if (error) throw error;
+      return data ?? null;
+    },
+  });
+
+export function useUserSettings(clientId = WEB_CLIENT_ID) {
+  return useQuery(userSettingsQueryOptions(clientId));
+}
+
+export function useUpsertUserSettings(clientId = WEB_CLIENT_ID) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (settings: ClientSettingsPayload) => {
+      const { data, error } = await upsertCurrentUserClientSettings({
+        path: { clientId },
+        body: { settings },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data) => {
+      qc.setQueryData(USER_SETTINGS_KEYS.detail(clientId), data ?? null);
+    },
+  });
+}
+
+export function useDeleteUserSettings(clientId = WEB_CLIENT_ID) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { error } = await deleteCurrentUserClientSettings({
+        path: { clientId },
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      qc.setQueryData(USER_SETTINGS_KEYS.detail(clientId), null);
+    },
+  });
+}

--- a/src/lib/clientSettings.test.ts
+++ b/src/lib/clientSettings.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useThemeStore } from '@/stores/theme.store';
+import { useUserPreferencesStore } from '@/stores/user-preferences.store';
+import {
+  applyWebSettings,
+  collectWebSettings,
+  parseWebSettings,
+  WEB_CLIENT_ID,
+} from './clientSettings';
+
+const themeDefaults = {
+  theme: 'system' as const,
+  primaryHue: 240,
+  fontSize: 16,
+  showNavLabels: true,
+  glassEffect: true,
+  showDescriptions: true,
+};
+
+const prefDefaults = {
+  currency: null,
+  dateFormat: 'medium' as const,
+  numberLocale: null,
+  isBalanceHidden: false,
+};
+
+beforeEach(() => {
+  useThemeStore.setState(themeDefaults);
+  useUserPreferencesStore.setState(prefDefaults);
+});
+
+describe('WEB_CLIENT_ID', () => {
+  it('is the conventional web client id', () => {
+    expect(WEB_CLIENT_ID).toBe('web');
+  });
+});
+
+describe('collectWebSettings', () => {
+  it('reads the persisted slices of both stores', () => {
+    useThemeStore.setState({ theme: 'dark', primaryHue: 120, fontSize: 18 });
+    useUserPreferencesStore.setState({ currency: 'EUR', isBalanceHidden: true });
+
+    expect(collectWebSettings()).toEqual({
+      ...themeDefaults,
+      ...prefDefaults,
+      theme: 'dark',
+      primaryHue: 120,
+      fontSize: 18,
+      currency: 'EUR',
+      isBalanceHidden: true,
+    });
+  });
+});
+
+describe('parseWebSettings', () => {
+  it('returns current settings when payload is empty', () => {
+    expect(parseWebSettings(undefined)).toEqual(collectWebSettings());
+    expect(parseWebSettings({})).toEqual(collectWebSettings());
+  });
+
+  it('accepts valid fields', () => {
+    const parsed = parseWebSettings({
+      theme: 'dark',
+      primaryHue: 200,
+      fontSize: 14,
+      showNavLabels: false,
+      glassEffect: false,
+      showDescriptions: false,
+      currency: 'USD',
+      dateFormat: 'long',
+      numberLocale: 'en-GB',
+      isBalanceHidden: true,
+    });
+    expect(parsed).toEqual({
+      theme: 'dark',
+      primaryHue: 200,
+      fontSize: 14,
+      showNavLabels: false,
+      glassEffect: false,
+      showDescriptions: false,
+      currency: 'USD',
+      dateFormat: 'long',
+      numberLocale: 'en-GB',
+      isBalanceHidden: true,
+    });
+  });
+
+  it('accepts explicit null for nullable fields', () => {
+    useUserPreferencesStore.setState({ currency: 'EUR', numberLocale: 'de-DE' });
+    const parsed = parseWebSettings({ currency: null, numberLocale: null });
+    expect(parsed.currency).toBeNull();
+    expect(parsed.numberLocale).toBeNull();
+  });
+
+  it('drops malformed fields, keeping current values', () => {
+    const parsed = parseWebSettings({
+      theme: 'neon',
+      primaryHue: 999,
+      fontSize: 4,
+      dateFormat: 'epoch',
+      showNavLabels: 'yes',
+    });
+    expect(parsed.theme).toBe('system');
+    expect(parsed.primaryHue).toBe(240);
+    expect(parsed.fontSize).toBe(16);
+    expect(parsed.dateFormat).toBe('medium');
+    expect(parsed.showNavLabels).toBe(true);
+  });
+
+  it('clamps hue/font to their inclusive bounds', () => {
+    expect(parseWebSettings({ primaryHue: 0, fontSize: 12 })).toMatchObject({
+      primaryHue: 0,
+      fontSize: 12,
+    });
+    expect(parseWebSettings({ primaryHue: 360, fontSize: 24 })).toMatchObject({
+      primaryHue: 360,
+      fontSize: 24,
+    });
+    expect(parseWebSettings({ primaryHue: 361, fontSize: 25 })).toMatchObject({
+      primaryHue: 240,
+      fontSize: 16,
+    });
+  });
+});
+
+describe('applyWebSettings', () => {
+  it('writes settings into both stores', () => {
+    applyWebSettings({
+      theme: 'light',
+      primaryHue: 30,
+      fontSize: 20,
+      showNavLabels: false,
+      glassEffect: false,
+      showDescriptions: false,
+      currency: 'GBP',
+      dateFormat: 'short',
+      numberLocale: 'fr-FR',
+      isBalanceHidden: true,
+    });
+
+    expect(useThemeStore.getState()).toMatchObject({
+      theme: 'light',
+      primaryHue: 30,
+      fontSize: 20,
+      showNavLabels: false,
+    });
+    expect(useUserPreferencesStore.getState()).toMatchObject({
+      currency: 'GBP',
+      dateFormat: 'short',
+      numberLocale: 'fr-FR',
+      isBalanceHidden: true,
+    });
+  });
+
+  it('round-trips through collect/parse/apply', () => {
+    useThemeStore.setState({ theme: 'dark', primaryHue: 99 });
+    useUserPreferencesStore.setState({ currency: 'JPY' });
+    const snapshot = collectWebSettings();
+
+    // reset, then re-apply the parsed snapshot
+    useThemeStore.setState(themeDefaults);
+    useUserPreferencesStore.setState(prefDefaults);
+    applyWebSettings(parseWebSettings(snapshot));
+
+    expect(collectWebSettings()).toEqual(snapshot);
+  });
+});

--- a/src/lib/clientSettings.test.ts
+++ b/src/lib/clientSettings.test.ts
@@ -107,7 +107,7 @@ describe('parseWebSettings', () => {
     expect(parsed.showNavLabels).toBe(true);
   });
 
-  it('clamps hue/font to their inclusive bounds', () => {
+  it('accepts hue/font at their inclusive bounds and drops out-of-range values', () => {
     expect(parseWebSettings({ primaryHue: 0, fontSize: 12 })).toMatchObject({
       primaryHue: 0,
       fontSize: 12,

--- a/src/lib/clientSettings.ts
+++ b/src/lib/clientSettings.ts
@@ -1,0 +1,106 @@
+import type { DateFormatStyle } from '@/lib/formatters';
+import { applyTheme, type Theme, useThemeStore } from '@/stores/theme.store';
+import { useUserPreferencesStore } from '@/stores/user-preferences.store';
+
+/**
+ * The `clientId` this web app uses to scope its per-client settings on the server.
+ * Other clients (mobile, telegram bot) own their own rows under different ids.
+ */
+export const WEB_CLIENT_ID = 'web';
+
+/**
+ * The persisted appearance + preference fields this client syncs to the server.
+ * Mirrors the persisted slices of the theme and user-preferences Zustand stores.
+ * The server treats this as an opaque blob — this module owns its schema.
+ */
+export interface WebClientSettings {
+  // theme store
+  theme: Theme;
+  primaryHue: number;
+  fontSize: number;
+  showNavLabels: boolean;
+  glassEffect: boolean;
+  showDescriptions: boolean;
+  // user-preferences store
+  currency: string | null;
+  dateFormat: DateFormatStyle;
+  numberLocale: string | null;
+  isBalanceHidden: boolean;
+}
+
+const THEMES: readonly Theme[] = ['light', 'dark', 'system'];
+const DATE_FORMATS: readonly DateFormatStyle[] = ['short', 'medium', 'long'];
+
+/** Read the current persisted settings from both stores into a single object. */
+export function collectWebSettings(): WebClientSettings {
+  const t = useThemeStore.getState();
+  const p = useUserPreferencesStore.getState();
+  return {
+    theme: t.theme,
+    primaryHue: t.primaryHue,
+    fontSize: t.fontSize,
+    showNavLabels: t.showNavLabels,
+    glassEffect: t.glassEffect,
+    showDescriptions: t.showDescriptions,
+    currency: p.currency,
+    dateFormat: p.dateFormat,
+    numberLocale: p.numberLocale,
+    isBalanceHidden: p.isBalanceHidden,
+  };
+}
+
+const isString = (v: unknown): v is string => typeof v === 'string';
+const isBool = (v: unknown): v is boolean => typeof v === 'boolean';
+const inRange = (v: unknown, min: number, max: number): v is number =>
+  typeof v === 'number' && Number.isFinite(v) && v >= min && v <= max;
+
+/**
+ * Validate an opaque server payload and merge it onto the current settings.
+ * Unknown or malformed fields are dropped (the server does not validate the
+ * shape, so we must), leaving the current local value untouched for that field.
+ */
+export function parseWebSettings(raw: unknown): WebClientSettings {
+  const current = collectWebSettings();
+  if (!raw || typeof raw !== 'object') return current;
+
+  const obj = raw as Record<string, unknown>;
+  const next: WebClientSettings = { ...current };
+  if (isString(obj.theme) && (THEMES as readonly string[]).includes(obj.theme)) {
+    next.theme = obj.theme as Theme;
+  }
+  if (inRange(obj.primaryHue, 0, 360)) next.primaryHue = obj.primaryHue;
+  if (inRange(obj.fontSize, 12, 24)) next.fontSize = obj.fontSize;
+  if (isBool(obj.showNavLabels)) next.showNavLabels = obj.showNavLabels;
+  if (isBool(obj.glassEffect)) next.glassEffect = obj.glassEffect;
+  if (isBool(obj.showDescriptions)) next.showDescriptions = obj.showDescriptions;
+  if (obj.currency === null || isString(obj.currency)) next.currency = obj.currency;
+  if (isString(obj.dateFormat) && (DATE_FORMATS as readonly string[]).includes(obj.dateFormat)) {
+    next.dateFormat = obj.dateFormat as DateFormatStyle;
+  }
+  if (obj.numberLocale === null || isString(obj.numberLocale)) next.numberLocale = obj.numberLocale;
+  if (isBool(obj.isBalanceHidden)) next.isBalanceHidden = obj.isBalanceHidden;
+  return next;
+}
+
+/**
+ * Write validated settings into both stores and apply the visual changes once.
+ * Uses `setState` rather than the individual setters so `applyTheme` runs a
+ * single time instead of once per field.
+ */
+export function applyWebSettings(settings: WebClientSettings): void {
+  useThemeStore.setState({
+    theme: settings.theme,
+    primaryHue: settings.primaryHue,
+    fontSize: settings.fontSize,
+    showNavLabels: settings.showNavLabels,
+    glassEffect: settings.glassEffect,
+    showDescriptions: settings.showDescriptions,
+  });
+  useUserPreferencesStore.setState({
+    currency: settings.currency,
+    dateFormat: settings.dateFormat,
+    numberLocale: settings.numberLocale,
+    isBalanceHidden: settings.isBalanceHidden,
+  });
+  applyTheme(settings.theme, settings.primaryHue, settings.fontSize);
+}


### PR DESCRIPTION
## Why

The contracts already expose per-client settings and user-lifecycle endpoints, but the web app never used them. App appearance/preferences lived only in `localStorage`, so they didn't follow users across devices, and there was no way to wipe financial data or delete an account from the UI.

## What changed

- **Two-way settings sync** — `useSettingsSync` (mounted once in `AppLayout`, authenticated-only) pulls the server's `web` client-settings row into the theme + user-preferences Zustand stores on login, **seeds** the server when no row exists, and **debounce-pushes** (1s) local changes. A last-synced JSON snapshot suppresses the pull's echo and skips no-op writes; a background refetch never re-hydrates mid-session.
- **`clientSettings.ts`** — owns (de)serialization between the two stores and the opaque server payload, validating untrusted server data and dropping malformed fields (theme enum, hue 0–360, font 12–24, etc.).
- **`useUserSettings`** — `get` (treats `404` as `null`), `upsert`, `delete` for the per-client settings row.
- **`useUserAccount`** — `useCurrentUser`, `useClearUserData` (wipes categories + transactions, invalidates financial caches), `useDeleteAccount` (IdP delete + cascade).
- **Danger Zone** — new Settings section with confirmation-gated "Clear all data" and "Delete account" actions; account delete clears the query cache and ends the session.

## How to verify

1. `pnpm install && pnpm test` — 291 tests pass (28 new, covering serialization/validation, all three hook modules, sync pull/seed/echo-suppression/debounced-push, and the Danger Zone component).
2. `pnpm lint && pnpm build` — both clean.
3. Manual: change theme/preferences in Settings → confirm a `PUT /v1/users/me/settings/web` fires after ~1s; reload in another session and confirm the values hydrate. Use Danger Zone → "Clear all data" and confirm transactions/categories empty; "Delete account" signs you out.

## Notes

- **Server wins on login**: when both local and server settings exist, the server's values are merged in on hydration — expected for cross-device sync, but an offline-only local change can be overwritten on the next fresh load.
- Session teardown after account delete relies on the IdP's end-session tolerating a deleted account, with a `removeUser` + hard-reload fallback.

## Code-review follow-ups (7788283)

Addressed findings from a review pass over the branch:

- **`DangerZoneSection` test coverage** — the one new file that previously had none. New tests cover the clear/delete flows, including the sign-out fallback that clears local credentials when the IdP rejects a deleted account, and the destructive-toast/retry paths.
- **Consistent error UX** — the delete-account dialog now stays open on error (lets the user retry), matching the clear-data flow.
- **Single source of truth for cache keys** — exported `TRANSACTIONS_KEYS` / `CATEGORIES_KEYS` and reused them in `useUserAccount` instead of raw `['transactions']` / `['categories']` literals.
- **Test-name fix** — a `clientSettings` test mislabelled "clamps" actually drops out-of-range values; renamed to match.
