### PR TITLE
fix: resolve SonarQube findings (security, correctness, code smells, style)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,14 @@ dist
 .git
 .gitignore
 
+# Environment files and secrets — never copy into the build context.
+# Runtime config is injected via envsubst at container start, not baked in.
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+
 # Editor and OS artefacts
 .DS_Store
 *.local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
 
       - name: Lint Pull Request title
         if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
-        run: echo "${{ github.event.pull_request.title }}" | pnpm exec commitlint --verbose
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | pnpm exec commitlint --verbose
 
       - name: Lint commit messages
         if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-  attestations: write    # for SBOM/provenance
-  id-token: write        # for keyless Cosign signing via OIDC
-  security-events: write # for uploading SARIF scan results
-
 env:
   IMAGE: ghcr.io/budget-buddy-org/budget-buddy-web-app
 
@@ -32,6 +25,11 @@ jobs:
             runner: ubuntu-24.04-arm
             cache-scope: buildx-arm64
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write       # push image by digest to GHCR
+      attestations: write   # for SBOM/provenance
+      id-token: write       # for keyless attestation via OIDC
     outputs:
       # Forward digests so downstream jobs can reference them.
       # Each matrix leg writes to a unique output via its PLATFORM env.
@@ -91,6 +89,10 @@ jobs:
   scan:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read         # pull image from GHCR to scan
+      security-events: write # upload SARIF scan results
     steps:
       - name: Download amd64 digest
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -152,6 +154,10 @@ jobs:
   merge:
     needs: [build, scan]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # push the multi-arch manifest list to GHCR
+      id-token: write  # for keyless Cosign signing via OIDC
     steps:
       - name: Download all digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/index.html
+++ b/index.html
@@ -16,27 +16,36 @@
     <title>Budget Buddy</title>
     <script>
       (function () {
+        var root = document.documentElement;
+
+        function applyHue(s, isDark) {
+          if (s.primaryHue === undefined) return;
+          root.style.setProperty('--primary-hue', s.primaryHue);
+          // Keep the live <meta name="theme-color"> in sync at first paint so the
+          // Android Chrome address bar doesn't flash the manifest-static blue.
+          var meta = document.querySelector('meta[name="theme-color"]');
+          if (meta) meta.setAttribute('content', 'hsl(' + s.primaryHue + ' 70% ' + (isDark ? 70 : 45) + '%)');
+        }
+
+        function applyTheme(s) {
+          var theme = s.theme || 'system';
+          var prefersDark = globalThis.matchMedia('(prefers-color-scheme: dark)').matches;
+          var isDark = theme === 'dark' || (theme === 'system' && prefersDark);
+          if (isDark) root.classList.add('dark');
+          root.style.colorScheme = isDark ? 'dark' : 'light';
+          applyHue(s, isDark);
+          if (s.fontSize !== undefined)
+            root.style.setProperty('--font-size-base', s.fontSize + 'px');
+        }
+
         try {
           var stored = localStorage.getItem('budget-buddy-theme');
-          if (stored) {
-            var s = JSON.parse(stored).state;
-            var theme = s.theme || 'system';
-            var isDark =
-              theme === 'dark' ||
-              (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-            if (isDark) document.documentElement.classList.add('dark');
-            document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
-            if (s.primaryHue !== undefined) {
-              document.documentElement.style.setProperty('--primary-hue', s.primaryHue);
-              // Keep the live <meta name="theme-color"> in sync at first paint so the
-              // Android Chrome address bar doesn't flash the manifest-static blue.
-              var meta = document.querySelector('meta[name="theme-color"]');
-              if (meta) meta.setAttribute('content', 'hsl(' + s.primaryHue + ' 70% ' + (isDark ? 70 : 45) + '%)');
-            }
-            if (s.fontSize !== undefined)
-              document.documentElement.style.setProperty('--font-size-base', s.fontSize + 'px');
-          }
-        } catch (e) {}
+          if (stored) applyTheme(JSON.parse(stored).state);
+        } catch (e) {
+          // Pre-hydration theming is best-effort; the React app re-applies the
+          // stored theme on mount, so a parse/storage failure here is non-fatal.
+          console.warn('Theme bootstrap failed:', e);
+        }
       })();
     </script>
     <style>

--- a/src/components/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog.tsx
@@ -30,7 +30,7 @@ export function ConfirmationDialog({
   cancelText = 'Cancel',
   variant = 'default',
   isLoading = false,
-}: ConfirmationDialogProps) {
+}: Readonly<ConfirmationDialogProps>) {
   const handleConfirm = () => {
     if (variant === 'destructive' && typeof navigator !== 'undefined' && 'vibrate' in navigator) {
       navigator.vibrate(50);

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -41,7 +41,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-function DefaultErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+function DefaultErrorFallback({ error, reset }: Readonly<{ error: Error; reset: () => void }>) {
   const [showDetails, setShowDetails] = useState(false);
 
   return (

--- a/src/components/VersionCheck.tsx
+++ b/src/components/VersionCheck.tsx
@@ -13,12 +13,12 @@ async function hardReload() {
       const regs = await navigator.serviceWorker.getRegistrations();
       await Promise.all(regs.map((r) => r.unregister()));
     }
-    if ('caches' in window) {
+    if ('caches' in globalThis) {
       const keys = await caches.keys();
       await Promise.all(keys.map((k) => caches.delete(k)));
     }
   } finally {
-    window.location.reload();
+    globalThis.location.reload();
   }
 }
 
@@ -60,7 +60,7 @@ export function VersionCheck() {
             altText="Reload app to update"
             onClick={() => {
               if (onReload) onReload();
-              else window.location.reload();
+              else globalThis.location.reload();
             }}
           >
             Reload
@@ -117,7 +117,7 @@ export function VersionCheck() {
   });
 
   // Handle updates from version.json. The SW may still be serving the old precache,
-  // so a plain window.location.reload() can come back as the same version. Nudge the
+  // so a plain location.reload() can come back as the same version. Nudge the
   // SW to update; if a waiting worker shows up, skip-waiting + reload via
   // updateServiceWorker(true). Otherwise fall back to a hard reload that unregisters
   // the SW and clears caches.

--- a/src/components/VersionCheck.tsx
+++ b/src/components/VersionCheck.tsx
@@ -22,6 +22,24 @@ async function hardReload() {
   }
 }
 
+// Resolve once a freshly-installed service worker is waiting, or after a timeout.
+function waitForWaitingWorker(registration: ServiceWorkerRegistration): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, SW_UPDATE_TIMEOUT);
+    const onUpdateFound = () => {
+      const installing = registration.installing;
+      if (!installing) return;
+      installing.addEventListener('statechange', () => {
+        if (installing.state === 'installed' && registration.waiting) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    };
+    registration.addEventListener('updatefound', onUpdateFound);
+  });
+}
+
 export function VersionCheck() {
   const { toast } = useToast();
   const lastCheckedVersion = useRef<string>(__APP_VERSION__);
@@ -130,20 +148,7 @@ export function VersionCheck() {
             return;
           }
 
-          await new Promise<void>((resolve) => {
-            const timeout = setTimeout(resolve, SW_UPDATE_TIMEOUT);
-            const onUpdateFound = () => {
-              const installing = registration.installing;
-              if (!installing) return;
-              installing.addEventListener('statechange', () => {
-                if (installing.state === 'installed' && registration.waiting) {
-                  clearTimeout(timeout);
-                  resolve();
-                }
-              });
-            };
-            registration.addEventListener('updatefound', onUpdateFound);
-          });
+          await waitForWaitingWorker(registration);
 
           if (registration.waiting) {
             updateServiceWorker(true);

--- a/src/components/categories/CategoriesPage.tsx
+++ b/src/components/categories/CategoriesPage.tsx
@@ -1,7 +1,7 @@
-import type { Category } from '@budget-buddy-org/budget-buddy-contracts';
+import type { Category, CategoryWrite } from '@budget-buddy-org/budget-buddy-contracts';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { Trash2, X } from 'lucide-react';
-import type { SubmitEvent } from 'react';
+import type { ReactNode, SubmitEvent } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { ConfirmationDialog } from '@/components/ConfirmationDialog';
 import { CategoryForm } from '@/components/categories/CategoryForm';
@@ -73,9 +73,22 @@ export function CategoriesPage() {
     navigate({ to: '/categories', search: {}, replace: true });
   }, [navigate]);
 
+  const restoreCategory = useCallback(
+    (snapshot: CategoryWrite) => {
+      createCategory.mutate(snapshot, {
+        onSuccess: () => toast({ title: 'Category restored', variant: 'success' }),
+        onError: () => toast({ title: "Couldn't restore category", variant: 'destructive' }),
+      });
+    },
+    [createCategory, toast],
+  );
+
   const handleDeleteCategory = useCallback(
     (category: Category) => {
-      const snapshot = { name: category.name, monthlyBudget: category.monthlyBudget ?? null };
+      const snapshot: CategoryWrite = {
+        name: category.name,
+        monthlyBudget: category.monthlyBudget ?? null,
+      };
       deleteCategory.mutate(category.id, {
         onSuccess: () => {
           setShowDeleteConfirm(false);
@@ -88,14 +101,7 @@ export function CategoriesPage() {
               <ToastAction
                 altText="Undo delete"
                 onClick={() => {
-                  createCategory.mutate(snapshot, {
-                    onSuccess: () => {
-                      toast({ title: 'Category restored', variant: 'success' });
-                    },
-                    onError: () => {
-                      toast({ title: "Couldn't restore category", variant: 'destructive' });
-                    },
-                  });
+                  restoreCategory(snapshot);
                   dismiss();
                 }}
               >
@@ -109,7 +115,7 @@ export function CategoriesPage() {
         },
       });
     },
-    [closeEdit, createCategory, deleteCategory, toast],
+    [closeEdit, deleteCategory, restoreCategory, toast],
   );
 
   const handleCreate = useCallback(
@@ -143,6 +149,26 @@ export function CategoriesPage() {
   );
 
   const categories = data?.items ?? [];
+
+  let categoriesBody: ReactNode;
+  if (isLoading) {
+    categoriesBody = <ListSkeleton count={6} />;
+  } else if (categories.length === 0) {
+    categoriesBody = <p className="px-6 py-4 text-sm text-muted-foreground">No categories yet.</p>;
+  } else {
+    categoriesBody = (
+      <ul className="divide-y">
+        {categories.map((c) => (
+          <CategoryRow
+            key={c.id}
+            name={c.name}
+            monthlyBudget={c.monthlyBudget ?? null}
+            onStartEdit={() => openEdit(c.id)}
+          />
+        ))}
+      </ul>
+    );
+  }
 
   return (
     <PageContainer>
@@ -267,24 +293,7 @@ export function CategoriesPage() {
       />
 
       <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <ListSkeleton count={6} />
-          ) : categories.length === 0 ? (
-            <p className="px-6 py-4 text-sm text-muted-foreground">No categories yet.</p>
-          ) : (
-            <ul className="divide-y">
-              {categories.map((c) => (
-                <CategoryRow
-                  key={c.id}
-                  name={c.name}
-                  monthlyBudget={c.monthlyBudget ?? null}
-                  onStartEdit={() => openEdit(c.id)}
-                />
-              ))}
-            </ul>
-          )}
-        </CardContent>
+        <CardContent className="p-0">{categoriesBody}</CardContent>
       </Card>
 
       {!isLoading && categories.length > 0 && (

--- a/src/components/categories/CategoryForm.tsx
+++ b/src/components/categories/CategoryForm.tsx
@@ -26,7 +26,7 @@ export function CategoryForm({
   error,
   isEditing = false,
   isDisabled = false,
-}: CategoryFormProps) {
+}: Readonly<CategoryFormProps>) {
   return (
     <form onSubmit={onSubmit} className="space-y-4">
       <FormField label="Name" required error={error} htmlFor="category-name">

--- a/src/components/categories/EditCategoryDialogBody.tsx
+++ b/src/components/categories/EditCategoryDialogBody.tsx
@@ -12,7 +12,10 @@ interface EditCategoryDialogBodyProps {
   onClose: () => void;
 }
 
-export function EditCategoryDialogBody({ category, onClose }: EditCategoryDialogBodyProps) {
+export function EditCategoryDialogBody({
+  category,
+  onClose,
+}: Readonly<EditCategoryDialogBodyProps>) {
   const { toast } = useToast();
   const updateCategory = useUpdateCategory(category.id);
 

--- a/src/components/dashboard/CategoriesCard.tsx
+++ b/src/components/dashboard/CategoriesCard.tsx
@@ -21,14 +21,14 @@ export function CategoriesCard({
   firstDayOfPeriod,
   lastDayOfPeriod,
   currency,
-}: {
+}: Readonly<{
   summary: CategorySpendingSummary | undefined;
   isLoading: boolean;
   periodLabel: string;
   firstDayOfPeriod: string;
   lastDayOfPeriod: string;
   currency: string;
-}) {
+}>) {
   const { fmtCurrency } = useFormatters();
   const [showAll, setShowAll] = useState(false);
   const isBalanceHidden = useUserPreferencesStore((s) => s.isBalanceHidden);
@@ -207,7 +207,7 @@ export function CategoriesCard({
   );
 }
 
-function PacingNote({ spent, budget }: { spent: number; budget: number }) {
+function PacingNote({ spent, budget }: Readonly<{ spent: number; budget: number }>) {
   const status = pacingStatus({ spent, budget, progress: monthProgress() });
   if (status === 'noBudget' || status === 'over') return null;
   if (status === 'under') {

--- a/src/components/dashboard/CategoriesCard.tsx
+++ b/src/components/dashboard/CategoriesCard.tsx
@@ -85,12 +85,9 @@ export function CategoriesCard({
                   const color = getCategoryColor(row.name);
                   const hasBudget = row.monthlyBudget != null;
                   const budget = row.monthlyBudget ?? 0;
-                  const pct =
-                    budget > 0
-                      ? Math.min(100, Math.round((row.spent / budget) * 100))
-                      : row.spent > 0
-                        ? 100
-                        : 0;
+                  let pct = 0;
+                  if (budget > 0) pct = Math.min(100, Math.round((row.spent / budget) * 100));
+                  else if (row.spent > 0) pct = 100;
                   const overBudget = hasBudget && row.spent > budget;
                   return (
                     <li key={row.categoryId} className="-mx-1 rounded-md p-1">

--- a/src/components/dashboard/MonthSelector.tsx
+++ b/src/components/dashboard/MonthSelector.tsx
@@ -32,14 +32,14 @@ export function MonthSelector({
   currentMonth,
   glassEffect,
   onChange,
-}: {
+}: Readonly<{
   year: number;
   month: number;
   currentYear: number;
   currentMonth: number;
   glassEffect: boolean;
   onChange: (year: number, month: number) => void;
-}) {
+}>) {
   const qc = useQueryClient();
   const preferredCurrency = useUserPreferencesStore((s) => s.currency);
   const currency = preferredCurrency ?? localeCurrency();
@@ -109,8 +109,8 @@ export function MonthSelector({
           break;
       }
     };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    globalThis.addEventListener('keydown', handler);
+    return () => globalThis.removeEventListener('keydown', handler);
   }, [move, open]);
 
   const prefetchPeriod = useCallback(

--- a/src/components/dashboard/RecentTransactionsCard.tsx
+++ b/src/components/dashboard/RecentTransactionsCard.tsx
@@ -13,11 +13,11 @@ export function RecentTransactionsCard({
   transactions,
   isLoading,
   hasFetched,
-}: {
+}: Readonly<{
   transactions: Transaction[];
   isLoading: boolean;
   hasFetched: boolean;
-}) {
+}>) {
   const navigate = useNavigate();
   const { fmtDate } = useFormatters();
 

--- a/src/components/dashboard/SummaryCard.tsx
+++ b/src/components/dashboard/SummaryCard.tsx
@@ -11,10 +11,10 @@ import { useUserPreferencesStore } from '@/stores/user-preferences.store';
 export function SummaryCardDescription({
   className,
   children,
-}: {
+}: Readonly<{
   className?: string;
   children: ReactNode;
-}) {
+}>) {
   return (
     <p className={cn('flex items-center gap-1 text-xs text-muted-foreground', className)}>
       {children}
@@ -30,7 +30,7 @@ export function SummaryCard({
   className,
   linkSearch,
   children,
-}: {
+}: Readonly<{
   label: string;
   amount: number;
   currency?: string;
@@ -38,7 +38,7 @@ export function SummaryCard({
   className: string;
   linkSearch?: TransactionSearch;
   children?: ReactNode;
-}) {
+}>) {
   const { fmtCurrency } = useFormatters();
   const isBalanceHidden = useUserPreferencesStore((s) => s.isBalanceHidden);
 
@@ -78,7 +78,7 @@ export function SummaryCard({
   return card;
 }
 
-export function SummaryCardSkeleton({ wide = false }: { wide?: boolean }) {
+export function SummaryCardSkeleton({ wide = false }: Readonly<{ wide?: boolean }>) {
   return (
     <Card glass className={cn('h-full', wide && 'col-span-2 md:col-span-1')}>
       <CardHeader className="pb-2">

--- a/src/components/layout/AppErrorComponent.tsx
+++ b/src/components/layout/AppErrorComponent.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from '@tanstack/react-router';
 import { useState } from 'react';
 
-export function AppErrorComponent({ error }: { error: Error }) {
+export function AppErrorComponent({ error }: Readonly<{ error: Error }>) {
   const router = useRouter();
   const [showDetails, setShowDetails] = useState(false);
 

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -5,7 +5,7 @@ import { FABProvider } from '@/contexts/fab-provider';
 import { Header } from './Header';
 import { MobileNav, SidebarNav } from './MobileNav';
 
-export function AppShell({ children }: { children: React.ReactNode }) {
+export function AppShell({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <FABProvider>
       <div className="flex min-h-dvh flex-col">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -23,7 +23,7 @@ export function Header() {
         to="/"
         className="font-semibold tracking-tight hover:opacity-80 active:opacity-60 transition-opacity motion-reduce:transition-none"
       >
-        Budget Buddy
+        <span>Budget Buddy</span>
         <span className="ml-1.5 text-xs font-normal text-muted-foreground">v{__APP_VERSION__}</span>
       </Link>
       <div className="flex items-center gap-1 sm:gap-2">

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -22,7 +22,7 @@ export function PageHeader({
   isSubtitleEssential,
   primaryAction,
   children,
-}: PageHeaderProps) {
+}: Readonly<PageHeaderProps>) {
   const showDescriptions = useThemeStore((s) => s.showDescriptions);
 
   // Register the primary action as the mobile FAB (clears on unmount)

--- a/src/components/layout/ProtectedAppLayout.tsx
+++ b/src/components/layout/ProtectedAppLayout.tsx
@@ -11,7 +11,7 @@ export function ProtectedAppLayout() {
     void auth.signinRedirect({
       // Preserve the current URL so onOidcSigninCallback can restore it after
       // the IdP redirect, instead of always landing on "/".
-      url_state: window.location.pathname + window.location.search,
+      url_state: globalThis.location.pathname + globalThis.location.search,
     });
   }, [auth]);
 

--- a/src/components/layout/RootErrorComponent.tsx
+++ b/src/components/layout/RootErrorComponent.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from '@tanstack/react-router';
 import { useState } from 'react';
 
-export function RootErrorComponent({ error }: { error: Error }) {
+export function RootErrorComponent({ error }: Readonly<{ error: Error }>) {
   const router = useRouter();
   const [showDetails, setShowDetails] = useState(false);
 

--- a/src/components/settings/DangerZoneSection.test.tsx
+++ b/src/components/settings/DangerZoneSection.test.tsx
@@ -63,7 +63,7 @@ async function openDialog(triggerName: RegExp) {
   return { user, dialog };
 }
 
-const originalLocation = window.location;
+const originalLocation = globalThis.location;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -72,14 +72,14 @@ beforeEach(() => {
     removeUser,
     signoutRedirect,
   } as unknown as ReturnType<typeof useAuth>);
-  Object.defineProperty(window, 'location', {
+  Object.defineProperty(globalThis, 'location', {
     configurable: true,
     value: { href: '/', pathname: '/', search: '' },
   });
 });
 
 afterEach(() => {
-  Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  Object.defineProperty(globalThis, 'location', { configurable: true, value: originalLocation });
 });
 
 describe('DangerZoneSection — clear data', () => {
@@ -127,7 +127,7 @@ describe('DangerZoneSection — delete account', () => {
     await user.click(within(dialog).getByRole('button', { name: /delete account/i }));
 
     await waitFor(() => expect(removeUser).toHaveBeenCalledTimes(1));
-    expect(window.location.href).toBe('/');
+    expect(globalThis.location.href).toBe('/');
   });
 
   it('shows a destructive toast and keeps the dialog open on failure', async () => {

--- a/src/components/settings/DangerZoneSection.tsx
+++ b/src/components/settings/DangerZoneSection.tsx
@@ -43,7 +43,7 @@ export function DangerZoneSection() {
           // The IdP end-session may reject a deleted account — clear the local
           // session and reload so the app falls back to the sign-in flow.
           await removeUser();
-          window.location.href = '/';
+          globalThis.location.href = '/';
         }
       },
       onError: () => {

--- a/src/components/settings/VersionSection.tsx
+++ b/src/components/settings/VersionSection.tsx
@@ -16,7 +16,7 @@ export function VersionSection() {
         <Button
           variant="outline"
           className="cursor-pointer"
-          onClick={() => window.location.reload()}
+          onClick={() => globalThis.location.reload()}
         >
           <RefreshCw className="size-4" />
           Reload App

--- a/src/components/transactions/CategoryCombobox.tsx
+++ b/src/components/transactions/CategoryCombobox.tsx
@@ -21,7 +21,7 @@ export function CategoryCombobox({
   disabled,
   error,
   id,
-}: CategoryComboboxProps) {
+}: Readonly<CategoryComboboxProps>) {
   const { toast } = useToast();
   const createCategory = useCreateCategory();
 

--- a/src/components/transactions/HeroAmountInput.tsx
+++ b/src/components/transactions/HeroAmountInput.tsx
@@ -54,12 +54,11 @@ export function HeroAmountInput({
 
   const displayValue = amount ? Number.parseFloat(amount).toFixed(2) : '';
 
-  const valueColor =
-    amountError && displayValue
-      ? 'text-destructive'
-      : type === 'INCOME' && displayValue
-        ? 'text-income'
-        : 'text-foreground';
+  let valueColor = 'text-foreground';
+  if (displayValue) {
+    if (amountError) valueColor = 'text-destructive';
+    else if (type === 'INCOME') valueColor = 'text-income';
+  }
 
   return (
     <div className="flex flex-col items-center gap-3">

--- a/src/components/transactions/HeroAmountInput.tsx
+++ b/src/components/transactions/HeroAmountInput.tsx
@@ -29,7 +29,7 @@ export function HeroAmountInput({
   typeError,
   currencyError,
   autoFocus,
-}: HeroAmountInputProps) {
+}: Readonly<HeroAmountInputProps>) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {

--- a/src/components/transactions/TransactionAmount.tsx
+++ b/src/components/transactions/TransactionAmount.tsx
@@ -10,7 +10,12 @@ interface TransactionAmountProps {
   className?: string;
 }
 
-export function TransactionAmount({ amount, currency, type, className }: TransactionAmountProps) {
+export function TransactionAmount({
+  amount,
+  currency,
+  type,
+  className,
+}: Readonly<TransactionAmountProps>) {
   const { fmtCurrency } = useFormatters();
   const isBalanceHidden = useUserPreferencesStore((s) => s.isBalanceHidden);
   const isIncome = type === 'INCOME';

--- a/src/components/transactions/TransactionFilters.tsx
+++ b/src/components/transactions/TransactionFilters.tsx
@@ -27,7 +27,7 @@ export function TransactionFilters({
   onFilterChange,
   onReset,
   onClose,
-}: TransactionFiltersProps) {
+}: Readonly<TransactionFiltersProps>) {
   // Edits are staged locally and committed on Done — the dialog covers the list, so live refetching is wasted work.
   const [prevFilters, setPrevFilters] = useState(filters);
   const [draft, setDraft] = useState<TransactionPageFilters>(filters);

--- a/src/components/transactions/TransactionForm.tsx
+++ b/src/components/transactions/TransactionForm.tsx
@@ -22,7 +22,11 @@ interface TransactionFormProps {
   transaction?: Transaction;
 }
 
-export function TransactionForm({ categories, onSuccess, transaction }: TransactionFormProps) {
+export function TransactionForm({
+  categories,
+  onSuccess,
+  transaction,
+}: Readonly<TransactionFormProps>) {
   const { toast } = useToast();
   const createTx = useCreateTransaction();
   const updateTx = useUpdateTransaction(transaction?.id ?? '');

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -49,10 +49,10 @@ export function TransactionList({
         groups.push(currentGroup);
       }
       currentGroup.items.push(t);
-      if (t.currency !== currentGroup.currency) {
-        currentGroup.currency = '';
-      } else {
+      if (t.currency === currentGroup.currency) {
         currentGroup.balance += t.type === 'INCOME' ? t.amount : -t.amount;
+      } else {
+        currentGroup.currency = '';
       }
     }
     return groups;
@@ -96,30 +96,31 @@ export function TransactionList({
 
   return (
     <div className="space-y-4">
-      {groupedTransactions.map((group) => (
-        <Card key={group.date}>
-          <CardContent className="p-0">
-            <h2 className="bg-muted px-4 py-1.5 text-xs font-semibold text-muted-foreground sticky top-0 z-10 flex items-center justify-between">
-              <span>{fmtRelativeDate(group.date)}</span>
-              <span className={cn(isBalanceHidden && 'privacy-blur')}>
-                {group.currency
-                  ? `${group.balance > 0 ? '+' : ''}${fmtCurrency(group.balance, group.currency)}`
-                  : 'N/A'}
-              </span>
-            </h2>
-            <ul className="divide-y">
-              {group.items.map((t) => (
-                <TransactionRow
-                  key={t.id}
-                  transaction={t}
-                  categoryName={t.categoryId ? categoryMap[t.categoryId] : undefined}
-                  onEdit={onEdit}
-                />
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      ))}
+      {groupedTransactions.map((group) => {
+        const sign = group.balance > 0 ? '+' : '';
+        return (
+          <Card key={group.date}>
+            <CardContent className="p-0">
+              <h2 className="bg-muted px-4 py-1.5 text-xs font-semibold text-muted-foreground sticky top-0 z-10 flex items-center justify-between">
+                <span>{fmtRelativeDate(group.date)}</span>
+                <span className={cn(isBalanceHidden && 'privacy-blur')}>
+                  {group.currency ? `${sign}${fmtCurrency(group.balance, group.currency)}` : 'N/A'}
+                </span>
+              </h2>
+              <ul className="divide-y">
+                {group.items.map((t) => (
+                  <TransactionRow
+                    key={t.id}
+                    transaction={t}
+                    categoryName={t.categoryId ? categoryMap[t.categoryId] : undefined}
+                    onEdit={onEdit}
+                  />
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        );
+      })}
       {isFetchingMore && (
         <Card aria-hidden="true">
           <CardContent className="p-0">

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -26,7 +26,7 @@ export function TransactionList({
   isFetchingMore = false,
   onResetFilters,
   onEdit,
-}: TransactionListProps) {
+}: Readonly<TransactionListProps>) {
   const { fmtCurrency, fmtRelativeDate } = useFormatters();
   const isBalanceHidden = useUserPreferencesStore((s) => s.isBalanceHidden);
   const categoryMap = useMemo(

--- a/src/components/transactions/TransactionSearchBar.tsx
+++ b/src/components/transactions/TransactionSearchBar.tsx
@@ -16,7 +16,7 @@ export function TransactionSearchBar({
   onQueryChange,
   onOpenFilters,
   isFiltered,
-}: TransactionSearchBarProps) {
+}: Readonly<TransactionSearchBarProps>) {
   const [local, setLocal] = useState(value);
   const [prevValue, setPrevValue] = useState(value);
   // Sync external value (e.g. URL reset) into local state during render.

--- a/src/components/transactions/TransactionsPage.tsx
+++ b/src/components/transactions/TransactionsPage.tsx
@@ -78,6 +78,13 @@ export function TransactionsPage() {
   const deleteTx = useDeleteTransaction();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
+  const restoreTransaction = (snapshot: TransactionWrite) => {
+    createTx.mutate(snapshot, {
+      onSuccess: () => toast({ title: 'Transaction restored', variant: 'success' }),
+      onError: () => toast({ title: "Couldn't restore transaction", variant: 'destructive' }),
+    });
+  };
+
   const handleDelete = () => {
     const tx = render.transaction;
     if (!tx?.id) return;
@@ -99,14 +106,7 @@ export function TransactionsPage() {
             <ToastAction
               altText="Undo delete"
               onClick={() => {
-                createTx.mutate(snapshot, {
-                  onSuccess: () => {
-                    toast({ title: 'Transaction restored', variant: 'success' });
-                  },
-                  onError: () => {
-                    toast({ title: "Couldn't restore transaction", variant: 'destructive' });
-                  },
-                });
+                restoreTransaction(snapshot);
                 dismiss();
               }}
             >

--- a/src/components/ui/amount-input.tsx
+++ b/src/components/ui/amount-input.tsx
@@ -20,7 +20,7 @@ function AmountInput({
   error,
   allowZero = false,
   ...props
-}: AmountInputProps) {
+}: Readonly<AmountInputProps>) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     // Extract digits only
     const digits = e.target.value.replaceAll(/\D/g, '');

--- a/src/components/ui/animated-number.tsx
+++ b/src/components/ui/animated-number.tsx
@@ -12,10 +12,10 @@ type Props = {
 const EASE_OUT_CUBIC = (t: number) => 1 - (1 - t) ** 3;
 
 function prefersReducedMotion(): boolean {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+  if (typeof globalThis.window === 'undefined' || typeof globalThis.matchMedia !== 'function') {
     return false;
   }
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  return globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
 /**
@@ -24,7 +24,7 @@ function prefersReducedMotion(): boolean {
  * changes animate. Reduced-motion settings collapse the animation to a single
  * frame so the value updates without movement.
  */
-export function AnimatedNumber({ value, duration = 600, format, className }: Props) {
+export function AnimatedNumber({ value, duration = 600, format, className }: Readonly<Props>) {
   const [display, setDisplay] = useState(value);
   // Updated synchronously inside `tick` so a mid-animation value change
   // animates from the *current* on-screen position, not a stale frame.

--- a/src/components/ui/animated-number.tsx
+++ b/src/components/ui/animated-number.tsx
@@ -12,7 +12,7 @@ type Props = {
 const EASE_OUT_CUBIC = (t: number) => 1 - (1 - t) ** 3;
 
 function prefersReducedMotion(): boolean {
-  if (typeof globalThis.window === 'undefined' || typeof globalThis.matchMedia !== 'function') {
+  if (globalThis.window === undefined || typeof globalThis.matchMedia !== 'function') {
     return false;
   }
   return globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;

--- a/src/components/ui/animated-number.tsx
+++ b/src/components/ui/animated-number.tsx
@@ -44,7 +44,7 @@ export function AnimatedNumber({ value, duration = 600, format, className }: Pro
     let start: number | null = null;
 
     const tick = (now: number) => {
-      if (start === null) start = now;
+      start ??= now;
       const elapsed = now - start;
       const t = effectiveDuration > 0 ? Math.min(1, elapsed / effectiveDuration) : 1;
       const eased = EASE_OUT_CUBIC(t);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -54,7 +54,7 @@ function Button({
       disabled={loading || disabled}
       {...props}
     >
-      {asChild ? children : loading ? renderLoadingChildren(children) : children}
+      {!asChild && loading ? renderLoadingChildren(children) : children}
     </Comp>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -39,7 +39,7 @@ function Button({
   disabled,
   ref,
   ...props
-}: ButtonProps) {
+}: Readonly<ButtonProps>) {
   const glassEffect = useThemeStore((s) => s.glassEffect);
   const Comp = asChild ? Slot : 'button';
   return (

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -37,7 +37,7 @@ export function Combobox({
   emptyLabel = 'No matches',
   ref,
   renderLeading,
-}: ComboboxProps) {
+}: Readonly<ComboboxProps>) {
   const reactId = useId();
   const listId = `${id ?? reactId}-list`;
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/ui/date-quick-picker.tsx
+++ b/src/components/ui/date-quick-picker.tsx
@@ -20,7 +20,7 @@ function yesterdayIso(): string {
   return toLocalIsoDate(d);
 }
 
-export function DateQuickPicker({ value, onChange, error, id }: DateQuickPickerProps) {
+export function DateQuickPicker({ value, onChange, error, id }: Readonly<DateQuickPickerProps>) {
   const glassEffect = useThemeStore((s) => s.glassEffect);
   const numberLocale = useUserPreferencesStore((s) => s.numberLocale ?? browserLocale());
   const pickerRef = useRef<HTMLInputElement>(null);
@@ -83,12 +83,12 @@ function ChipTab({
   glassEffect,
   onClick,
   children,
-}: {
+}: Readonly<{
   selected: boolean;
   glassEffect: boolean | undefined;
   onClick: () => void;
   children: React.ReactNode;
-}) {
+}>) {
   return (
     <button
       type="button"

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -14,7 +14,7 @@ interface EmptyStateProps {
 /**
  * A standard empty state component for lists and dashboards.
  */
-export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+export function EmptyState({ icon, title, description, action }: Readonly<EmptyStateProps>) {
   return (
     <div className="flex flex-col items-center justify-center gap-4 px-6 py-12 text-center">
       {icon && <div className="rounded-pill bg-muted p-3">{icon}</div>}

--- a/src/components/ui/form-field.tsx
+++ b/src/components/ui/form-field.tsx
@@ -20,7 +20,7 @@ export function FormField({
   className,
   required,
   htmlFor,
-}: FormFieldProps) {
+}: Readonly<FormFieldProps>) {
   return (
     <div className={cn('space-y-1', className)}>
       {label && (

--- a/src/components/ui/infinite-scroll-sentinel.tsx
+++ b/src/components/ui/infinite-scroll-sentinel.tsx
@@ -13,7 +13,7 @@ export function InfiniteScrollSentinel({
   isFetchingNextPage,
   onLoadMore,
   total,
-}: InfiniteScrollSentinelProps) {
+}: Readonly<InfiniteScrollSentinelProps>) {
   const ref = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {

--- a/src/components/ui/list-item.tsx
+++ b/src/components/ui/list-item.tsx
@@ -19,7 +19,7 @@ export function ListItem({
   className,
   as: Component = 'li',
   ariaLabel,
-}: ListItemProps) {
+}: Readonly<ListItemProps>) {
   const content = (
     <button
       type="button"

--- a/src/components/ui/list-skeleton.tsx
+++ b/src/components/ui/list-skeleton.tsx
@@ -12,7 +12,11 @@ const SKELETON_KEYS = Array.from({ length: 20 }, (_, i) => `sk-${i}`);
 /**
  * A generic skeleton for lists of items (transactions, categories, etc.)
  */
-export function ListSkeleton({ count = 5, className, showIcon = false }: ListSkeletonProps) {
+export function ListSkeleton({
+  count = 5,
+  className,
+  showIcon = false,
+}: Readonly<ListSkeletonProps>) {
   return (
     <div className={cn('divide-y', className)}>
       {SKELETON_KEYS.slice(0, count).map((key) => (

--- a/src/components/ui/page-container.tsx
+++ b/src/components/ui/page-container.tsx
@@ -9,6 +9,6 @@ interface PageContainerProps {
 /**
  * Standard container for all top-level pages to ensure consistent spacing.
  */
-export function PageContainer({ children, className }: PageContainerProps) {
+export function PageContainer({ children, className }: Readonly<PageContainerProps>) {
   return <div className={cn('space-y-6', className)}>{children}</div>;
 }

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -11,7 +11,13 @@ interface PaginationProps {
   className?: string;
 }
 
-export function Pagination({ page, total, size, onPageChange, className }: PaginationProps) {
+export function Pagination({
+  page,
+  total,
+  size,
+  onPageChange,
+  className,
+}: Readonly<PaginationProps>) {
   const totalPages = Math.max(1, Math.ceil(total / size));
 
   if (totalPages <= 1) {

--- a/src/components/ui/section-header.tsx
+++ b/src/components/ui/section-header.tsx
@@ -11,7 +11,7 @@ interface SectionHeaderProps {
  * A reusable section header with an optional icon.
  * Used primarily in Settings and multisection pages.
  */
-export function SectionHeader({ title, icon: Icon, className }: SectionHeaderProps) {
+export function SectionHeader({ title, icon: Icon, className }: Readonly<SectionHeaderProps>) {
   return (
     <div className={cn('flex items-center gap-2', className)}>
       {Icon && <Icon className="size-4 text-primary" />}

--- a/src/components/ui/section.tsx
+++ b/src/components/ui/section.tsx
@@ -18,7 +18,13 @@ interface SectionProps {
  * into a single primitive. Default Card padding/spacing matches the established
  * Settings rhythm; pass `cardClassName` to override.
  */
-export function Section({ title, icon, children, cardClassName, className }: SectionProps) {
+export function Section({
+  title,
+  icon,
+  children,
+  cardClassName,
+  className,
+}: Readonly<SectionProps>) {
   return (
     <section className={cn('space-y-3', className)}>
       <SectionHeader title={title} icon={icon} />

--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -50,9 +50,9 @@ export function Sparkline({
   const path = points
     .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`)
     .join(' ');
-  const area = `${path} L${points[points.length - 1][0].toFixed(2)} ${HEIGHT - PADDING} L${points[0][0].toFixed(2)} ${HEIGHT - PADDING} Z`;
+  const last = points.at(-1) ?? points[0];
+  const area = `${path} L${last[0].toFixed(2)} ${HEIGHT - PADDING} L${points[0][0].toFixed(2)} ${HEIGHT - PADDING} Z`;
   const stroke = VARIANT_STROKE[variant];
-  const last = points[points.length - 1];
   const dotLeft = `${(last[0] / WIDTH) * 100}%`;
   const dotTop = `${(last[1] / HEIGHT) * 100}%`;
 

--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -17,12 +17,12 @@ export function Sparkline({
   isLoading = false,
   variant = 'balance',
   className,
-}: {
+}: Readonly<{
   values: number[];
   isLoading?: boolean;
   variant?: SparklineVariant;
   className?: string;
-}) {
+}>) {
   if (isLoading || values.length < 2) {
     return (
       <div

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -7,7 +7,7 @@ export interface SwitchProps extends React.InputHTMLAttributes<HTMLInputElement>
   ref?: React.Ref<HTMLInputElement>;
 }
 
-function Switch({ className, checked, onCheckedChange, ref, ...props }: SwitchProps) {
+function Switch({ className, checked, onCheckedChange, ref, ...props }: Readonly<SwitchProps>) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onCheckedChange?.(e.target.checked);
   };

--- a/src/contexts/fab-provider.tsx
+++ b/src/contexts/fab-provider.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { type FABAction, FABContext } from './fab-context';
 
-export function FABProvider({ children }: { children: ReactNode }) {
+export function FABProvider({ children }: Readonly<{ children: ReactNode }>) {
   // Store label/icon in state (drives re-renders), onClick in a ref (always current, no re-renders)
   const [fabMeta, setFabMeta] = useState<{ label: string; icon?: ReactNode } | null>(null);
   const onClickRef = useRef<(() => void) | null>(null);

--- a/src/contexts/fab-provider.tsx
+++ b/src/contexts/fab-provider.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { type FABAction, FABContext } from './fab-context';
 
 export function FABProvider({ children }: { children: ReactNode }) {
@@ -17,9 +17,15 @@ export function FABProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const fab: FABAction | null = fabMeta
-    ? { ...fabMeta, onClick: () => onClickRef.current?.() }
-    : null;
+  // Memoize so the context value is stable across renders that don't change
+  // fabMeta. The onClick closure reads onClickRef, so it stays current without
+  // needing to be part of the dependency list.
+  const value = useMemo(() => {
+    const fab: FABAction | null = fabMeta
+      ? { ...fabMeta, onClick: () => onClickRef.current?.() }
+      : null;
+    return { fab, setFAB };
+  }, [fabMeta, setFAB]);
 
-  return <FABContext.Provider value={{ fab, setFAB }}>{children}</FABContext.Provider>;
+  return <FABContext.Provider value={value}>{children}</FABContext.Provider>;
 }

--- a/src/hooks/useInstallPrompt.ts
+++ b/src/hooks/useInstallPrompt.ts
@@ -13,14 +13,14 @@ function emitChange() {
 
 // Capture the event globally (fires once per page load, before any React
 // component may have mounted).
-if (typeof window !== 'undefined') {
-  window.addEventListener('beforeinstallprompt', (e) => {
+if (typeof globalThis.window !== 'undefined') {
+  globalThis.addEventListener('beforeinstallprompt', (e) => {
     e.preventDefault();
     deferredPrompt = e as BeforeInstallPromptEvent;
     emitChange();
   });
 
-  window.addEventListener('appinstalled', () => {
+  globalThis.addEventListener('appinstalled', () => {
     deferredPrompt = null;
     emitChange();
   });

--- a/src/hooks/useInstallPrompt.ts
+++ b/src/hooks/useInstallPrompt.ts
@@ -13,7 +13,7 @@ function emitChange() {
 
 // Capture the event globally (fires once per page load, before any React
 // component may have mounted).
-if (typeof globalThis.window !== 'undefined') {
+if (globalThis.window !== undefined) {
   globalThis.addEventListener('beforeinstallprompt', (e) => {
     e.preventDefault();
     deferredPrompt = e as BeforeInstallPromptEvent;

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,11 +1,11 @@
 import { useSyncExternalStore } from 'react';
 
 function subscribe(callback: () => void) {
-  window.addEventListener('online', callback);
-  window.addEventListener('offline', callback);
+  globalThis.addEventListener('online', callback);
+  globalThis.addEventListener('offline', callback);
   return () => {
-    window.removeEventListener('online', callback);
-    window.removeEventListener('offline', callback);
+    globalThis.removeEventListener('online', callback);
+    globalThis.removeEventListener('offline', callback);
   };
 }
 

--- a/src/hooks/useTransactionPageState.ts
+++ b/src/hooks/useTransactionPageState.ts
@@ -96,7 +96,7 @@ export function useTransactionPageState() {
         categoryId: newFilters.categoryId || undefined,
         start: newFilters.start || undefined,
         end: newFilters.end || undefined,
-        sort: newFilters.sort !== 'desc' ? newFilters.sort : undefined,
+        sort: newFilters.sort === 'desc' ? undefined : newFilters.sort,
         type: newFilters.type || undefined,
         query: newFilters.query || undefined,
         amountMin: newFilters.amountMin,

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -160,6 +160,27 @@ export function useUpdateTransaction(id: string) {
   });
 }
 
+// Remove a transaction by id from an infinite cache. Every page carries the same
+// meta.total, so on a successful removal we decrement total across all pages to keep
+// them consistent. Returns the original data unchanged if the id wasn't present.
+function removeFromInfiniteData(
+  data: InfiniteData<PaginatedTransactions>,
+  id: string,
+): InfiniteData<PaginatedTransactions> {
+  let removed = false;
+  const pages = data.pages.map((p) => {
+    const nextItems = p.items.filter((t) => t.id !== id);
+    if (nextItems.length === p.items.length) return p;
+    removed = true;
+    return { ...p, items: nextItems };
+  });
+  if (!removed) return data;
+  return {
+    ...data,
+    pages: pages.map((p) => ({ ...p, meta: { ...p.meta, total: Math.max(0, p.meta.total - 1) } })),
+  };
+}
+
 export function useDeleteTransaction() {
   const qc = useQueryClient();
   return useMutation({
@@ -190,24 +211,7 @@ export function useDeleteTransaction() {
       // Same for infinite caches (different shape: { pages, pageParams }).
       qc.setQueriesData<InfiniteData<PaginatedTransactions>>(
         { queryKey: ['transactions', 'infinite'] },
-        (old) => {
-          if (!old) return old;
-          let removed = false;
-          const pages = old.pages.map((p) => {
-            const nextItems = p.items.filter((t) => t.id !== id);
-            if (nextItems.length === p.items.length) return p;
-            removed = true;
-            return { ...p, items: nextItems };
-          });
-          if (!removed) return old;
-          return {
-            ...old,
-            pages: pages.map((p) => ({
-              ...p,
-              meta: { ...p.meta, total: Math.max(0, p.meta.total - 1) },
-            })),
-          };
-        },
+        (old) => (old ? removeFromInfiniteData(old, id) : old),
       );
 
       return { previous };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -70,7 +70,7 @@ client.interceptors.response.use(async (response, request) => {
       const refreshed = await refreshSilently();
       if (!refreshed) {
         await getUserManager().signinRedirect({
-          url_state: window.location.pathname + window.location.search,
+          url_state: globalThis.location.pathname + globalThis.location.search,
         });
       }
     }

--- a/src/lib/categoryColor.ts
+++ b/src/lib/categoryColor.ts
@@ -5,7 +5,7 @@ const HUES = [210, 250, 280, 310, 335, 25, 50, 70, 160, 185] as const;
 function hashString(str: string): number {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
-    hash = (hash * 31 + str.charCodeAt(i)) >>> 0; // keep unsigned 32-bit
+    hash = (hash * 31 + (str.codePointAt(i) ?? 0)) >>> 0; // keep unsigned 32-bit
   }
   return hash;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -44,15 +44,13 @@ export async function loadConfig(): Promise<AppConfig> {
     }
   }
 
-  if (!config) {
-    config = {
-      VITE_API_URL: import.meta.env.VITE_API_URL ?? 'http://localhost:8080',
-      VITE_OIDC_ISSUER: import.meta.env.VITE_OIDC_ISSUER ?? '',
-      VITE_OIDC_CLIENT_ID: import.meta.env.VITE_OIDC_CLIENT_ID ?? '',
-      VITE_OIDC_SCOPES: import.meta.env.VITE_OIDC_SCOPES ?? undefined,
-      VITE_OIDC_USER_MANAGEMENT_URL: import.meta.env.VITE_OIDC_USER_MANAGEMENT_URL ?? undefined,
-    };
-  }
+  config ??= {
+    VITE_API_URL: import.meta.env.VITE_API_URL ?? 'http://localhost:8080',
+    VITE_OIDC_ISSUER: import.meta.env.VITE_OIDC_ISSUER ?? '',
+    VITE_OIDC_CLIENT_ID: import.meta.env.VITE_OIDC_CLIENT_ID ?? '',
+    VITE_OIDC_SCOPES: import.meta.env.VITE_OIDC_SCOPES ?? undefined,
+    VITE_OIDC_USER_MANAGEMENT_URL: import.meta.env.VITE_OIDC_USER_MANAGEMENT_URL ?? undefined,
+  };
 
   return config;
 }

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -150,9 +150,7 @@ export function localeCurrency(): string {
 
 let _currencyDisplayNames: Intl.DisplayNames | null = null;
 function getCurrencyDisplayNames(): Intl.DisplayNames {
-  if (!_currencyDisplayNames) {
-    _currencyDisplayNames = new Intl.DisplayNames([browserLocale()], { type: 'currency' });
-  }
+  _currencyDisplayNames ??= new Intl.DisplayNames([browserLocale()], { type: 'currency' });
   return _currencyDisplayNames;
 }
 

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -28,7 +28,7 @@ function isSupported(): boolean {
 
 function prefersReducedMotion(): boolean {
   if (cachedReducedMotion !== null) return cachedReducedMotion;
-  if (typeof globalThis.window === 'undefined' || typeof globalThis.matchMedia !== 'function') {
+  if (globalThis.window === undefined || typeof globalThis.matchMedia !== 'function') {
     cachedReducedMotion = false;
     return false;
   }

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -28,11 +28,11 @@ function isSupported(): boolean {
 
 function prefersReducedMotion(): boolean {
   if (cachedReducedMotion !== null) return cachedReducedMotion;
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+  if (typeof globalThis.window === 'undefined' || typeof globalThis.matchMedia !== 'function') {
     cachedReducedMotion = false;
     return false;
   }
-  const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const mql = globalThis.matchMedia('(prefers-reduced-motion: reduce)');
   cachedReducedMotion = mql.matches;
   // Live-update if the user changes the setting mid-session.
   mql.addEventListener?.('change', (e) => {

--- a/src/lib/oidc.test.ts
+++ b/src/lib/oidc.test.ts
@@ -7,8 +7,8 @@ describe('buildOidcSettings', () => {
 
     expect(settings.authority).toBe('https://issuer.example.com');
     expect(settings.client_id).toBe('web-client');
-    expect(settings.redirect_uri).toBe(`${window.location.origin}/auth/callback`);
-    expect(settings.post_logout_redirect_uri).toBe(`${window.location.origin}/`);
+    expect(settings.redirect_uri).toBe(`${globalThis.location.origin}/auth/callback`);
+    expect(settings.post_logout_redirect_uri).toBe(`${globalThis.location.origin}/`);
     expect(settings.response_type).toBe('code');
     // default scopes include openid and offline_access
     expect(settings.scope).toBe('openid profile email offline_access');
@@ -73,7 +73,7 @@ describe('getUserManager / initUserManager', () => {
   });
 
   afterEach(() => {
-    window.history.replaceState({}, '', '/');
+    globalThis.history.replaceState({}, '', '/');
   });
 
   it('throws before initUserManager is called', async () => {
@@ -96,32 +96,32 @@ describe('getUserManager / initUserManager', () => {
 
 describe('onOidcSigninCallback', () => {
   afterEach(() => {
-    window.history.replaceState({}, '', '/');
+    globalThis.history.replaceState({}, '', '/');
   });
 
   it('strips OIDC params from the URL after signin', () => {
-    window.history.replaceState({}, '', '/auth/callback?code=test&state=test');
+    globalThis.history.replaceState({}, '', '/auth/callback?code=test&state=test');
 
     onOidcSigninCallback(undefined);
 
-    expect(window.location.pathname).toBe('/');
-    expect(window.location.search).toBe('');
+    expect(globalThis.location.pathname).toBe('/');
+    expect(globalThis.location.search).toBe('');
   });
 
   it('restores the original deep-link URL from url_state', () => {
-    window.history.replaceState({}, '', '/auth/callback?code=test&state=test');
+    globalThis.history.replaceState({}, '', '/auth/callback?code=test&state=test');
 
     onOidcSigninCallback({ url_state: '/transactions?page=2' });
 
-    expect(window.location.pathname).toBe('/transactions');
-    expect(window.location.search).toBe('?page=2');
+    expect(globalThis.location.pathname).toBe('/transactions');
+    expect(globalThis.location.search).toBe('?page=2');
   });
 
   it('falls back to "/" when url_state is not a string', () => {
-    window.history.replaceState({}, '', '/auth/callback?code=test&state=test');
+    globalThis.history.replaceState({}, '', '/auth/callback?code=test&state=test');
 
     onOidcSigninCallback({ url_state: 42 });
 
-    expect(window.location.pathname).toBe('/');
+    expect(globalThis.location.pathname).toBe('/');
   });
 });

--- a/src/lib/oidc.ts
+++ b/src/lib/oidc.ts
@@ -84,5 +84,5 @@ export function onOidcSigninCallback(user: unknown): void {
       ? user.url_state
       : '/';
 
-  window.history.replaceState({}, document.title, returnUrl);
+  globalThis.history.replaceState({}, document.title, returnUrl);
 }

--- a/src/lib/oidc.ts
+++ b/src/lib/oidc.ts
@@ -80,11 +80,8 @@ export function getUserManager(): UserManager {
  */
 export function onOidcSigninCallback(user: unknown): void {
   const returnUrl =
-    user &&
-    typeof user === 'object' &&
-    'url_state' in user &&
-    typeof (user as { url_state: unknown }).url_state === 'string'
-      ? (user as { url_state: string }).url_state
+    user && typeof user === 'object' && 'url_state' in user && typeof user.url_state === 'string'
+      ? user.url_state
       : '/';
 
   window.history.replaceState({}, document.title, returnUrl);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -31,41 +31,40 @@ if (!rootEl) throw new Error('Root element not found');
 
 // Bootstrapping: load runtime config, initialise the OIDC UserManager and API
 // client with the resolved values, then render the app.
-loadConfig()
-  .then(async (config) => {
-    client.setConfig({ baseUrl: config.VITE_API_URL });
-    // UserManager must be initialised before the first React render so that
-    // api.ts interceptors and ProtectedAppLayout can call getUserManager().
-    const userManager = initUserManager(
-      config.VITE_OIDC_ISSUER,
-      config.VITE_OIDC_CLIENT_ID,
-      config.VITE_OIDC_SCOPES,
-    );
+try {
+  const config = await loadConfig();
+  client.setConfig({ baseUrl: config.VITE_API_URL });
+  // UserManager must be initialised before the first React render so that
+  // api.ts interceptors and ProtectedAppLayout can call getUserManager().
+  const userManager = initUserManager(
+    config.VITE_OIDC_ISSUER,
+    config.VITE_OIDC_CLIENT_ID,
+    config.VITE_OIDC_SCOPES,
+  );
 
-    userManager.events.addSilentRenewError((error) => {
-      logError(error, { source: 'SilentRenewError' });
-    });
-
-    createRoot(rootEl).render(
-      <StrictMode>
-        <AuthProvider userManager={userManager} onSigninCallback={onOidcSigninCallback}>
-          <QueryClientProvider client={queryClient}>
-            <RouterProvider router={router} />
-          </QueryClientProvider>
-        </AuthProvider>
-      </StrictMode>,
-    );
-  })
-  .catch((err) => {
-    console.error('[BOOTSTRAP] Config loading failed:', err);
-    createRoot(rootEl).render(
-      <div className="flex min-h-screen items-center justify-center p-6 text-center">
-        <div className="max-w-xs">
-          <h1 className="text-xl font-semibold">Failed to load configuration</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Please check your connection and try again.
-          </p>
-        </div>
-      </div>,
-    );
+  userManager.events.addSilentRenewError((error) => {
+    logError(error, { source: 'SilentRenewError' });
   });
+
+  createRoot(rootEl).render(
+    <StrictMode>
+      <AuthProvider userManager={userManager} onSigninCallback={onOidcSigninCallback}>
+        <QueryClientProvider client={queryClient}>
+          <RouterProvider router={router} />
+        </QueryClientProvider>
+      </AuthProvider>
+    </StrictMode>,
+  );
+} catch (err) {
+  console.error('[BOOTSTRAP] Config loading failed:', err);
+  createRoot(rootEl).render(
+    <div className="flex min-h-screen items-center justify-center p-6 text-center">
+      <div className="max-w-xs">
+        <h1 className="text-xl font-semibold">Failed to load configuration</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Please check your connection and try again.
+        </p>
+      </div>
+    </div>,
+  );
+}

--- a/src/routes/_app/transactions/index.tsx
+++ b/src/routes/_app/transactions/index.tsx
@@ -19,19 +19,20 @@ export interface TransactionSearch {
 const validAmount = (v: unknown): number | undefined =>
   typeof v === 'number' && Number.isFinite(v) && v >= 1 ? Math.floor(v) : undefined;
 
+const validSort = (v: unknown): 'asc' | 'desc' | undefined =>
+  v === 'asc' || v === 'desc' ? v : undefined;
+
+const validType = (v: unknown): 'EXPENSE' | 'INCOME' | '' | undefined =>
+  v === 'EXPENSE' || v === 'INCOME' || v === '' ? v : undefined;
+
 export const Route = createFileRoute('/_app/transactions/')({
   pendingComponent: TransactionsSkeleton,
   validateSearch: (search: Record<string, unknown>): TransactionSearch => ({
     categoryId: typeof search.categoryId === 'string' ? search.categoryId : undefined,
     start: typeof search.start === 'string' ? search.start : undefined,
     end: typeof search.end === 'string' ? search.end : undefined,
-    sort: search.sort === 'asc' ? 'asc' : search.sort === 'desc' ? 'desc' : undefined,
-    type:
-      search.type === 'EXPENSE' || search.type === 'INCOME'
-        ? search.type
-        : search.type === ''
-          ? ''
-          : undefined,
+    sort: validSort(search.sort),
+    type: validType(search.type),
     query: typeof search.query === 'string' && search.query.length > 0 ? search.query : undefined,
     amountMin: validAmount(search.amountMin),
     amountMax: validAmount(search.amountMax),

--- a/src/stores/theme.store.test.ts
+++ b/src/stores/theme.store.test.ts
@@ -24,7 +24,7 @@ describe('useThemeStore', () => {
     document.documentElement.style.removeProperty('--primary-hue');
     document.documentElement.style.removeProperty('--font-size-base');
 
-    Object.defineProperty(window, 'matchMedia', {
+    Object.defineProperty(globalThis, 'matchMedia', {
       configurable: true,
       writable: true,
       value: vi.fn().mockImplementation(() => ({

--- a/src/stores/theme.store.ts
+++ b/src/stores/theme.store.ts
@@ -22,7 +22,7 @@ interface ThemeState {
 }
 
 function getSystemTheme(): 'light' | 'dark' {
-  if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) return 'light';
+  if (globalThis.window === undefined || !globalThis.matchMedia) return 'light';
   return globalThis.matchMedia(SYSTEM_THEME_MEDIA).matches ? 'dark' : 'light';
 }
 
@@ -55,8 +55,7 @@ export function applyTheme(theme: Theme, primaryHue: number, fontSize: number) {
 let systemThemeCleanup: (() => void) | null = null;
 
 function attachSystemThemeListener(getState: () => ThemeState) {
-  if (systemThemeCleanup || typeof globalThis.window === 'undefined' || !globalThis.matchMedia)
-    return;
+  if (systemThemeCleanup || globalThis.window === undefined || !globalThis.matchMedia) return;
 
   const mediaQuery = globalThis.matchMedia(SYSTEM_THEME_MEDIA);
   const handleSystemThemeChange = () => {

--- a/src/stores/theme.store.ts
+++ b/src/stores/theme.store.ts
@@ -22,8 +22,8 @@ interface ThemeState {
 }
 
 function getSystemTheme(): 'light' | 'dark' {
-  if (typeof window === 'undefined' || !window.matchMedia) return 'light';
-  return window.matchMedia(SYSTEM_THEME_MEDIA).matches ? 'dark' : 'light';
+  if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) return 'light';
+  return globalThis.matchMedia(SYSTEM_THEME_MEDIA).matches ? 'dark' : 'light';
 }
 
 function syncMetaThemeColor(resolved: 'light' | 'dark', primaryHue: number) {
@@ -55,9 +55,10 @@ export function applyTheme(theme: Theme, primaryHue: number, fontSize: number) {
 let systemThemeCleanup: (() => void) | null = null;
 
 function attachSystemThemeListener(getState: () => ThemeState) {
-  if (systemThemeCleanup || typeof window === 'undefined' || !window.matchMedia) return;
+  if (systemThemeCleanup || typeof globalThis.window === 'undefined' || !globalThis.matchMedia)
+    return;
 
-  const mediaQuery = window.matchMedia(SYSTEM_THEME_MEDIA);
+  const mediaQuery = globalThis.matchMedia(SYSTEM_THEME_MEDIA);
   const handleSystemThemeChange = () => {
     const { theme, primaryHue, fontSize } = getState();
     if (theme === 'system') {

--- a/src/test/__mocks__/pwa-register.ts
+++ b/src/test/__mocks__/pwa-register.ts
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 
 export function useRegisterSW() {
+  const [needRefresh, setNeedRefresh] = useState(false);
+  const [offlineReady, setOfflineReady] = useState(false);
   return {
-    needRefresh: useState(false),
-    offlineReady: useState(false),
+    needRefresh: [needRefresh, setNeedRefresh] as const,
+    offlineReady: [offlineReady, setOfflineReady] as const,
     updateServiceWorker: () => Promise.resolve(),
   };
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -44,9 +44,9 @@ const localStorageMock = (() => {
   };
 })();
 
-Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
 
 // Mock scrollTo since it's not implemented in JSDOM
-if (typeof window !== 'undefined') {
+if (typeof globalThis.window !== 'undefined') {
   Element.prototype.scrollTo = vi.fn();
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -47,6 +47,6 @@ const localStorageMock = (() => {
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
 
 // Mock scrollTo since it's not implemented in JSDOM
-if (typeof globalThis.window !== 'undefined') {
+if (globalThis.window !== undefined) {
   Element.prototype.scrollTo = vi.fn();
 }


### PR DESCRIPTION
## Summary

Resolves the open **SonarQube** findings for `budget-buddy-org_budget-buddy-web-app` (1 BLOCKER, 12 CRITICAL, 17 MAJOR, ~106 MINOR + 2 hotspots). Organised as four logical commits on one branch.

### 🔒 Security & CI (`fix(ci)`)
- **BLOCKER** `githubactions:S7630` — PR title was interpolated directly into a `run` block in `ci.yml` (script-injection vector). Now bound to an env var.
- `S8264`/`S8233` — workflow-level permissions in `publish.yml` moved down to each job (least privilege per build/scan/merge).
- `docker:S6470` — exclude `.env*`/`*.pem`/`*.key` from the Docker build context so the recursive `COPY` can't leak secrets.

### ✅ Correctness (`fix`)
- `S6481` — `FABContext` provider value was a new object every render; now `useMemo`-stabilised.
- `S2486` — `index.html` theme bootstrap no longer silently swallows its `catch`.
- `S4325` — dropped redundant type assertions in `onOidcSigninCallback`.

### 🧹 Code smells (`refactor`)
- `S3358` ×7 — nested ternaries extracted into helpers / early branches.
- `S2004` ×6 — delete/undo callback chains and the infinite-cache delete update flattened via hoisted helpers.
- `S7785` — `main.tsx` bootstrap converted to top-level `await`.
- `S3776` (`index.html` complexity), `S6606` (`??=`), `S7735`, `S7755` (`Array#at`), `S7758`, `S6772`, `S6754`.

### 🎨 Style (`style`)
- `S7764` ×50 — `window` → `globalThis` (existence guards use `typeof globalThis.window` to keep non-browser semantics).
- `S6759` ×41 — component prop annotations wrapped in `Readonly<…>`.

## Deliberately not changed (intentional / false positives)
- `S3735` void-operator ×5 — intentional fire-and-forget markers (e.g. `void auth.signinRedirect(...)`).
- `S6819` ×2 — `role="img"`+`aria-label` on the inline `<svg>` sparkline and the custom `role="listbox"` combobox are correct ARIA patterns; Sonar's `<img>`/`<select>` suggestions don't apply.
- `S4325` ×2 — `combobox` `e.target as Node` is required by `tsc`; the toggle cast is needed because destructuring loses discriminated-union narrowing.
- `docker:S6471` (nginx-as-root) — left as a hardening follow-up.

These remaining items should be marked *Accepted / Safe* in SonarQube.

## Verification
- `pnpm lint` ✅  `pnpm type-check` ✅  `pnpm test` ✅ (291 passing)  `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)