### PR TITLE
fix(auth): redeem refresh token before redirect on iOS PWA cold start

### DIFF
--- a/src/components/layout/ProtectedAppLayout.test.tsx
+++ b/src/components/layout/ProtectedAppLayout.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { useAuth } from 'react-oidc-context';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProtectedAppLayout } from './ProtectedAppLayout';
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/components/layout/AppLayout', () => ({
+  AppLayout: () => <div data-testid="app-layout">app</div>,
+}));
+
+function mockAuth(overrides: Partial<ReturnType<typeof useAuth>>) {
+  const auth = {
+    isLoading: false,
+    isAuthenticated: false,
+    activeNavigator: undefined,
+    user: undefined,
+    signinSilent: vi.fn().mockResolvedValue({}),
+    signinRedirect: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ReturnType<typeof useAuth>;
+  vi.mocked(useAuth).mockReturnValue(auth);
+  return auth;
+}
+
+describe('ProtectedAppLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the app when authenticated', () => {
+    mockAuth({ isAuthenticated: true });
+    render(<ProtectedAppLayout />);
+    expect(screen.getByTestId('app-layout')).toBeInTheDocument();
+  });
+
+  it('does nothing while auth is still loading', () => {
+    const auth = mockAuth({ isLoading: true });
+    render(<ProtectedAppLayout />);
+    expect(auth.signinSilent).not.toHaveBeenCalled();
+    expect(auth.signinRedirect).not.toHaveBeenCalled();
+  });
+
+  it('shows a session-restoring message during a silent renew', () => {
+    mockAuth({ activeNavigator: 'signinSilent' });
+    render(<ProtectedAppLayout />);
+    expect(screen.getByText('Restoring your session…')).toBeInTheDocument();
+  });
+
+  it('shows a redirecting message during an interactive sign-in', () => {
+    mockAuth({ activeNavigator: 'signinRedirect' });
+    render(<ProtectedAppLayout />);
+    expect(screen.getByText('Redirecting to sign-in…')).toBeInTheDocument();
+  });
+
+  it('tries a silent refresh-token renewal before redirecting on cold start', async () => {
+    const auth = mockAuth({ user: { refresh_token: 'rt' } as never });
+    render(<ProtectedAppLayout />);
+
+    await waitFor(() => expect(auth.signinSilent).toHaveBeenCalledTimes(1));
+    expect(auth.signinRedirect).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an interactive redirect when the refresh token is rejected', async () => {
+    const auth = mockAuth({ user: { refresh_token: 'rt' } as never });
+    vi.mocked(auth.signinSilent).mockRejectedValueOnce(new Error('expired'));
+
+    render(<ProtectedAppLayout />);
+
+    await waitFor(() => expect(auth.signinRedirect).toHaveBeenCalledTimes(1));
+    expect(auth.signinSilent).toHaveBeenCalledTimes(1);
+    expect(auth.signinRedirect).toHaveBeenCalledWith(
+      expect.objectContaining({ url_state: expect.any(String) }),
+    );
+  });
+
+  it('redirects immediately when there is no refresh token to redeem', async () => {
+    const auth = mockAuth({ user: undefined });
+    render(<ProtectedAppLayout />);
+
+    await waitFor(() => expect(auth.signinRedirect).toHaveBeenCalledTimes(1));
+    expect(auth.signinSilent).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/ProtectedAppLayout.tsx
+++ b/src/components/layout/ProtectedAppLayout.tsx
@@ -1,30 +1,60 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { AppLayout } from '@/components/layout/AppLayout';
 
 export function ProtectedAppLayout() {
   const auth = useAuth();
+  // Guards the one-shot silent-renew attempt below so a rejected refresh token
+  // can't loop: signinSilent fails → re-render → signinSilent → …
+  const triedSilentRenew = useRef(false);
 
   useEffect(() => {
     if (auth.isLoading || auth.activeNavigator || auth.isAuthenticated) return;
 
-    auth.signinRedirect({
-      // Preserve the current URL so onOidcSigninCallback can restore it after
-      // the IdP redirect, instead of always landing on "/".
-      url_state: globalThis.location.pathname + globalThis.location.search,
-    });
+    void (async () => {
+      // Cold start with an expired access token — the norm on iOS PWAs, which
+      // suspend JS timers in the background, so automaticSilentRenew never runs
+      // before the token expires. Redeem the still-valid refresh token first:
+      // it restores the session in place, with no jarring redirect to the IdP
+      // and no dependency on the IdP's SSO cookie surviving Safari ITP. Only a
+      // genuinely expired/rejected refresh token falls through to interactive
+      // sign-in. signinSilent is deduped in oidc.ts, so this can't race the
+      // request interceptor or visibility listener into a double redemption.
+      if (auth.user?.refresh_token && !triedSilentRenew.current) {
+        triedSilentRenew.current = true;
+        try {
+          await auth.signinSilent();
+          return; // success fires USER_LOADED → isAuthenticated flips → app renders
+        } catch {
+          // refresh token rejected/expired — fall through to interactive sign-in
+        }
+      }
+
+      await auth.signinRedirect({
+        // Preserve the current URL so onOidcSigninCallback can restore it after
+        // the IdP redirect, instead of always landing on "/".
+        url_state: globalThis.location.pathname + globalThis.location.search,
+      });
+    })();
   }, [auth]);
 
   if (auth.isLoading || auth.activeNavigator) {
+    // A silent refresh-token renewal restores the session in place; only the
+    // interactive paths actually leave for the IdP.
+    const message =
+      auth.activeNavigator === 'signinSilent'
+        ? 'Restoring your session…'
+        : 'Redirecting to sign-in…';
     return (
       <div className="flex min-h-screen items-center justify-center p-6 text-center">
-        <p className="text-sm text-muted-foreground">Redirecting to sign-in…</p>
+        <p className="text-sm text-muted-foreground">{message}</p>
       </div>
     );
   }
 
-  // signinRedirect() is in-flight — show a loading state so the user never
-  // sees a blank screen between the unauthenticated render and the redirect.
+  // A silent renew or signinRedirect() is in-flight — show a loading state so
+  // the user never sees a blank screen between the unauthenticated render and
+  // the redirect.
   if (!auth.isAuthenticated) {
     return (
       <div className="flex min-h-screen items-center justify-center p-6 text-center">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,21 +2,23 @@ import { client } from '@budget-buddy-org/budget-buddy-contracts/client.gen';
 import type { User } from 'oidc-client-ts';
 import { getUserManager } from '@/lib/oidc';
 
-// Only proactively refresh when the token is basically gone. The SDK's
-// automaticSilentRenew already fires 60s before expiry; overlapping with it
-// causes duplicate refresh-token redemptions, which IdPs that enable
-// refresh-token rotation treat as token theft and invalidate the session.
-// This safety net only kicks in when the SDK's setTimeout was throttled or
-// killed in a backgrounded tab.
+// Only proactively refresh when the token is basically gone. In the normal case
+// the SDK's automaticSilentRenew (which fires ~60s before expiry) handles
+// renewal; this safety net only kicks in when that setTimeout was throttled or
+// killed in a backgrounded tab. Duplicate redemptions of a rotating refresh
+// token (which IdPs treat as theft and revoke the whole family) are prevented
+// globally by coalesceSilentRenew() in oidc.ts, which funnels every
+// signinSilent() — this module's, the SDK's, and the route guard's — through a
+// single in-flight redemption.
 const REFRESH_THRESHOLD_SECONDS = 10;
 
-// Match the SDK's automaticSilentRenew window so both paths share pendingSilentRenew
-// and only one refresh-token redemption occurs per expiry cycle.
+// On tab re-focus, refresh within the same ~60s window the SDK targets so the
+// token is fresh before the first API call fires.
 const VISIBILITY_REFRESH_THRESHOLD_SECONDS = 60;
 
-// Dedupe concurrent refreshes. Multiple in-flight API requests must share a
-// single signinSilent() call; otherwise we redeem the same refresh token N
-// times in parallel and get rotated out.
+// Dedupe this module's own concurrent refreshes onto one signinSilent() call.
+// (coalesceSilentRenew() in oidc.ts additionally dedupes across the SDK and the
+// route guard.)
 let pendingSilentRenew: Promise<User | null> | null = null;
 
 function refreshSilently(): Promise<User | null> {
@@ -79,16 +81,12 @@ client.interceptors.response.use(async (response, request) => {
 });
 
 // When a background tab is re-focused, the SDK's automaticSilentRenew timer may
-// have been throttled by the browser, leaving an expired token in storage. Both
-// the SDK's delayed timer and the first API request's getAuthToken() safety net
-// then call signinSilent() concurrently — redeeming the same refresh token twice.
-// IdPs with refresh-token rotation treat duplicate redemptions as token theft and
-// invalidate the entire session.
-//
-// A visibilitychange listener proactively refreshes within the same 60-second
-// window the SDK targets, before any API calls fire. Because it goes through
-// refreshSilently(), it shares pendingSilentRenew with both getAuthToken() and the
-// SDK's delayed timer, ensuring only one token redemption ever occurs.
+// have been throttled by the browser, leaving an expired token in storage. This
+// visibilitychange listener proactively refreshes within the same ~60s window the
+// SDK targets, before any API call fires, so requests never go out with a stale
+// token. Going through refreshSilently() (and ultimately coalesceSilentRenew() in
+// oidc.ts) guarantees this never races the SDK's delayed timer or getAuthToken()
+// into a duplicate refresh-token redemption.
 if (typeof document !== 'undefined') {
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState !== 'visible') return;

--- a/src/lib/oidc.test.ts
+++ b/src/lib/oidc.test.ts
@@ -1,5 +1,6 @@
+import type { UserManager } from 'oidc-client-ts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildOidcSettings, onOidcSigninCallback } from './oidc';
+import { buildOidcSettings, coalesceSilentRenew, onOidcSigninCallback } from './oidc';
 
 describe('buildOidcSettings', () => {
   it('builds settings from issuer and clientId with default scopes', () => {
@@ -91,6 +92,77 @@ describe('getUserManager / initUserManager', () => {
     );
 
     expect(freshGet()).toBe(mgr);
+  });
+});
+
+describe('coalesceSilentRenew', () => {
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  it('merges overlapping calls into a single underlying redemption', async () => {
+    const d = deferred<{ access_token: string }>();
+    const original = vi.fn(() => d.promise);
+    const um = { signinSilent: original } as unknown as UserManager;
+
+    coalesceSilentRenew(um);
+
+    const calls = [um.signinSilent(), um.signinSilent(), um.signinSilent()];
+    expect(original).toHaveBeenCalledTimes(1);
+
+    d.resolve({ access_token: 'fresh' });
+    const results = await Promise.all(calls);
+    expect(results).toEqual([
+      { access_token: 'fresh' },
+      { access_token: 'fresh' },
+      { access_token: 'fresh' },
+    ]);
+  });
+
+  it('allows a fresh redemption once the previous one settles', async () => {
+    const first = deferred<{ access_token: string }>();
+    const second = deferred<{ access_token: string }>();
+    const original = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const um = { signinSilent: original } as unknown as UserManager;
+
+    coalesceSilentRenew(um);
+
+    const p1 = um.signinSilent();
+    first.resolve({ access_token: 'one' });
+    await p1;
+
+    const p2 = um.signinSilent();
+    second.resolve({ access_token: 'two' });
+    await p2;
+
+    expect(original).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the in-flight promise after a rejection so renews can be retried', async () => {
+    const failing = deferred<{ access_token: string }>();
+    const succeeding = deferred<{ access_token: string }>();
+    const original = vi
+      .fn()
+      .mockReturnValueOnce(failing.promise)
+      .mockReturnValueOnce(succeeding.promise);
+    const um = { signinSilent: original } as unknown as UserManager;
+
+    coalesceSilentRenew(um);
+
+    const p1 = um.signinSilent();
+    failing.reject(new Error('rotation reuse'));
+    await expect(p1).rejects.toThrow('rotation reuse');
+
+    const p2 = um.signinSilent();
+    succeeding.resolve({ access_token: 'recovered' });
+    await expect(p2).resolves.toEqual({ access_token: 'recovered' });
+    expect(original).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/lib/oidc.test.ts
+++ b/src/lib/oidc.test.ts
@@ -95,17 +95,17 @@ describe('getUserManager / initUserManager', () => {
   });
 });
 
-describe('coalesceSilentRenew', () => {
-  function deferred<T>() {
-    let resolve!: (value: T) => void;
-    let reject!: (reason?: unknown) => void;
-    const promise = new Promise<T>((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
-    return { promise, resolve, reject };
-  }
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
+describe('coalesceSilentRenew', () => {
   it('merges overlapping calls into a single underlying redemption', async () => {
     const d = deferred<{ access_token: string }>();
     const original = vi.fn(() => d.promise);

--- a/src/lib/oidc.ts
+++ b/src/lib/oidc.ts
@@ -1,4 +1,9 @@
-import { UserManager, type UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts';
+import {
+  type User,
+  UserManager,
+  type UserManagerSettings,
+  WebStorageStateStore,
+} from 'oidc-client-ts';
 
 let _userManager: UserManager | null = null;
 
@@ -50,6 +55,31 @@ export function buildOidcSettings(
 }
 
 /**
+ * Coalesces concurrent silent-renew calls into a single in-flight refresh-token
+ * redemption.
+ *
+ * Zitadel (like most IdPs) rotates the refresh token on every redemption and
+ * treats a second redemption of the now-rotated token as token theft, revoking
+ * the entire token family. On an iOS PWA cold start several renew triggers can
+ * fire at once — the SDK's automaticSilentRenew, the route guard, the API
+ * request interceptor and the visibilitychange listener — each calling
+ * userManager.signinSilent(). Both react-oidc-context's navigator wrappers and
+ * the SDK's SilentRenewService invoke the public instance method, so wrapping it
+ * here funnels every path through one redemption. Sequential renews (the normal
+ * rotation cycle) are unaffected — only overlapping calls are merged.
+ */
+export function coalesceSilentRenew(userManager: UserManager): void {
+  const original = userManager.signinSilent.bind(userManager);
+  let inFlight: Promise<User | null> | null = null;
+  userManager.signinSilent = ((args?: Parameters<UserManager['signinSilent']>[0]) => {
+    inFlight ??= Promise.resolve(original(args)).finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
+  }) as UserManager['signinSilent'];
+}
+
+/**
  * Initializes the shared UserManager with runtime-loaded OIDC config.
  * Must be called once in main.tsx after loadConfig() resolves, before rendering.
  */
@@ -59,6 +89,7 @@ export function initUserManager(
   extraScopes?: string,
 ): UserManager {
   _userManager = new UserManager(buildOidcSettings(issuer, clientId, extraScopes));
+  coalesceSilentRenew(_userManager);
   return _userManager;
 }
 


### PR DESCRIPTION
## Why

iOS PWAs suspend JS timers in the background, so `automaticSilentRenew` never runs while the app is closed and the access token expires overnight. On the next cold start, `react-oidc-context` reports `isAuthenticated=false` and the route guard went straight to a full `signinRedirect()` — a jarring bounce to the IdP that also fails when Safari ITP has aged out the IdP's SSO cookie. Result: a fresh login screen roughly every day on iOS, while warm Chrome desktop tabs were unaffected.

## What changed

- **Route guard redeems the refresh token first** (`ProtectedAppLayout.tsx`): on cold start it calls `signinSilent()` to restore the session in place — no navigation, no dependency on the IdP cookie surviving ITP — and only falls back to an interactive redirect when the refresh token is genuinely rejected. A `useRef` guards the one-shot attempt so a bad token can't loop.
- **Global `signinSilent` coalescing** (`coalesceSilentRenew` in `oidc.ts`): Zitadel rotates the refresh token on every redemption and revokes the whole token family if the rotated token is reused. On cold start the SDK's `automaticSilentRenew`, the route guard, the request interceptor, and the visibility listener could each call `signinSilent()` concurrently and double-redeem. Wrapping the public instance method (which both react-oidc-context and the SDK's `SilentRenewService` call) funnels every path through one in-flight redemption.
- **Loading copy** distinguishes a silent renew (*"Restoring your session…"*) from an interactive redirect.
- **Updated stale `api.ts` comments** to point at the global coalescing, since its local dedup is now superseded for cross-path safety.

## How to verify

- `pnpm lint && pnpm test && pnpm build` — all green (300 tests).
- New tests: `coalesceSilentRenew` (merge concurrent / allow sequential / recover after rejection) and `ProtectedAppLayout` (silent-first, fallback-on-reject, redirect-when-no-RT, loading copy).
- On a real iOS device: install the PWA, sign in, leave it backgrounded overnight (or until the access token expires), reopen — you should land directly in the app with no sign-in screen.

## Notes

- App-side fix is the primary lever; on the Zitadel side, confirm the app's **Refresh Token Idle/Absolute Expiration** comfortably exceeds the longest gap between opens (defaults are generous). If those were tightened to ~1 day, the symptom could recur regardless.
- The guard attempts at most one silent renew per mount; later in-session expiries are handled by `automaticSilentRenew` and the 401 handler.