### PR TITLE
fix: scroll to top after create, stop auto-focusing amount input

### DIFF
--- a/src/components/categories/CategoriesPage.tsx
+++ b/src/components/categories/CategoriesPage.tsx
@@ -27,6 +27,7 @@ import {
 import { useLatchedValue } from '@/hooks/useLatchedValue';
 import { getApiError } from '@/lib/api-error';
 import { inputToMinorUnits } from '@/lib/category-budget';
+import { scrollToTop } from '@/lib/scroll';
 
 export function CategoriesPage() {
   const search = useSearch({ from: '/_app/categories/' });
@@ -52,7 +53,7 @@ export function CategoriesPage() {
 
   const handlePageChange = useCallback((newPage: number) => {
     setPage(newPage);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    scrollToTop();
   }, []);
 
   const [newName, setNewName] = useState('');
@@ -130,6 +131,7 @@ export function CategoriesPage() {
             setNewBudget('');
             setShowForm(false);
             setPage(0);
+            scrollToTop();
             toast({ title: 'Category created', variant: 'success' });
           },
           onError: (error) => {

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { useFABContext } from '@/hooks/use-fab';
 import { cn } from '@/lib/cn';
 import { haptic } from '@/lib/haptics';
+import { scrollToTop } from '@/lib/scroll';
 import { useThemeStore } from '@/stores/theme.store';
 
 const NAV_ITEMS = [
@@ -20,7 +21,7 @@ export function MobileNav() {
   const handleTap = useCallback(
     (to: string) => {
       if (to === currentPath) {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+        scrollToTop();
       } else {
         haptic('tap');
       }

--- a/src/components/transactions/HeroAmountInput.tsx
+++ b/src/components/transactions/HeroAmountInput.tsx
@@ -1,6 +1,5 @@
 import { ChevronDown } from 'lucide-react';
 import type * as React from 'react';
-import { useEffect, useRef } from 'react';
 import { TransactionTypeToggle } from '@/components/ui/transaction-type-toggle';
 import { cn } from '@/lib/cn';
 import { ISO_CURRENCIES } from '@/lib/formatters';
@@ -15,7 +14,6 @@ interface HeroAmountInputProps {
   amountError?: boolean;
   typeError?: boolean;
   currencyError?: boolean;
-  autoFocus?: boolean;
 }
 
 export function HeroAmountInput({
@@ -28,16 +26,7 @@ export function HeroAmountInput({
   amountError,
   typeError,
   currencyError,
-  autoFocus,
 }: Readonly<HeroAmountInputProps>) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (autoFocus) {
-      inputRef.current?.focus();
-    }
-  }, [autoFocus]);
-
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const digits = e.target.value.replaceAll(/\D/g, '');
     if (!digits) {
@@ -71,7 +60,6 @@ export function HeroAmountInput({
 
       {/* Amount — full-width centred so the number is always the focal point */}
       <input
-        ref={inputRef}
         type="text"
         inputMode="decimal"
         placeholder="0.00"

--- a/src/components/transactions/TransactionForm.test.tsx
+++ b/src/components/transactions/TransactionForm.test.tsx
@@ -40,7 +40,6 @@ vi.mock('@/components/transactions/HeroAmountInput', () => ({
     onTypeChange,
     onAmountChange,
     onCurrencyChange,
-    autoFocus,
   }: {
     type: 'EXPENSE' | 'INCOME';
     amount: string;
@@ -48,7 +47,6 @@ vi.mock('@/components/transactions/HeroAmountInput', () => ({
     onTypeChange: (v: 'EXPENSE' | 'INCOME') => void;
     onAmountChange: (v: string) => void;
     onCurrencyChange: (v: string) => void;
-    autoFocus?: boolean;
   }) =>
     React.createElement(
       'div',
@@ -58,7 +56,6 @@ vi.mock('@/components/transactions/HeroAmountInput', () => ({
         placeholder: '0.00',
         value: amount,
         onChange: (e: React.ChangeEvent<HTMLInputElement>) => onAmountChange(e.target.value),
-        'data-autofocus': autoFocus ? 'true' : 'false',
       }),
       React.createElement(
         'select',
@@ -334,21 +331,8 @@ describe('TransactionForm', () => {
     });
   });
 
-  it('forwards autoFocus to HeroAmountInput in create mode but not in edit mode', () => {
-    const { unmount } = renderForm();
-    expect(screen.getByLabelText('amount-test')).toHaveAttribute('data-autofocus', 'true');
-    unmount();
-
-    const transaction = {
-      id: 'tx-1',
-      description: 'Old Coffee',
-      amount: 500,
-      currency: 'EUR',
-      type: 'EXPENSE' as const,
-      date: '2024-01-01',
-      categoryId: 'cat-1',
-    };
-    renderForm({ transaction });
-    expect(screen.getByLabelText('amount-test')).toHaveAttribute('data-autofocus', 'false');
+  it('does not auto-focus the amount input on open so the keyboard stays dismissed', () => {
+    renderForm();
+    expect(screen.getByLabelText('amount-test')).not.toHaveFocus();
   });
 });

--- a/src/components/transactions/TransactionForm.tsx
+++ b/src/components/transactions/TransactionForm.tsx
@@ -118,7 +118,6 @@ export function TransactionForm({
         amountError={!!amountError}
         typeError={!!getFieldError('type')}
         currencyError={!!getFieldError('currency')}
-        autoFocus={!isEditing}
       />
       {amountError && (
         <p className="text-xs font-medium text-destructive text-center -mt-2">{amountError}</p>

--- a/src/components/transactions/TransactionsPage.tsx
+++ b/src/components/transactions/TransactionsPage.tsx
@@ -31,6 +31,7 @@ import {
   useInfiniteTransactions,
   useTransaction,
 } from '@/hooks/useTransactions';
+import { scrollToTop } from '@/lib/scroll';
 
 export function TransactionsPage() {
   const { toast } = useToast();
@@ -73,6 +74,15 @@ export function TransactionsPage() {
 
   const dialogTitle = render.mode === 'edit' ? 'Edit Transaction' : 'Add Transaction';
   const showSkeleton = isDialogOpen && isEditing && isTransactionLoading && !editingTransaction;
+
+  // After a successful save, close the dialog. For new transactions, also scroll
+  // to the top so the freshly created (newest-first) entry is in view — editing
+  // leaves the existing row in place, so we don't move the viewport then.
+  const handleFormSuccess = () => {
+    const wasAdding = !isEditing;
+    closeForm();
+    if (wasAdding) scrollToTop();
+  };
 
   const createTx = useCreateTransaction();
   const deleteTx = useDeleteTransaction();
@@ -227,7 +237,7 @@ export function TransactionsPage() {
               key={render.mode === 'edit' ? (render.transaction?.id ?? 'edit') : 'add'}
               categories={categories}
               transaction={render.transaction}
-              onSuccess={closeForm}
+              onSuccess={handleFormSuccess}
             />
           )}
         </DialogContent>

--- a/src/lib/scroll.test.ts
+++ b/src/lib/scroll.test.ts
@@ -1,18 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { scrollToTop } from './scroll';
 
+function mockReducedMotion(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({ matches })),
+  );
+}
+
 describe('scrollToTop', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
-
-  function mockReducedMotion(matches: boolean) {
-    vi.stubGlobal(
-      'matchMedia',
-      vi.fn(() => ({ matches })),
-    );
-  }
 
   it('scrolls to the top smoothly by default', () => {
     mockReducedMotion(false);

--- a/src/lib/scroll.test.ts
+++ b/src/lib/scroll.test.ts
@@ -2,17 +2,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { scrollToTop } from './scroll';
 
 describe('scrollToTop', () => {
-  const originalMatchMedia = globalThis.matchMedia;
-
   afterEach(() => {
-    globalThis.matchMedia = originalMatchMedia;
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
   function mockReducedMotion(matches: boolean) {
-    globalThis.matchMedia = vi
-      .fn()
-      .mockReturnValue({ matches }) as unknown as typeof globalThis.matchMedia;
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches })),
+    );
   }
 
   it('scrolls to the top smoothly by default', () => {
@@ -34,8 +33,7 @@ describe('scrollToTop', () => {
   });
 
   it('falls back to smooth when matchMedia is unavailable', () => {
-    // @ts-expect-error simulate an environment without matchMedia
-    globalThis.matchMedia = undefined;
+    vi.stubGlobal('matchMedia', undefined);
     const scrollSpy = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {});
 
     scrollToTop();

--- a/src/lib/scroll.test.ts
+++ b/src/lib/scroll.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { scrollToTop } from './scroll';
+
+describe('scrollToTop', () => {
+  const originalMatchMedia = globalThis.matchMedia;
+
+  afterEach(() => {
+    globalThis.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
+  });
+
+  function mockReducedMotion(matches: boolean) {
+    globalThis.matchMedia = vi
+      .fn()
+      .mockReturnValue({ matches }) as unknown as typeof globalThis.matchMedia;
+  }
+
+  it('scrolls to the top smoothly by default', () => {
+    mockReducedMotion(false);
+    const scrollSpy = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {});
+
+    scrollToTop();
+
+    expect(scrollSpy).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+
+  it('jumps instantly when the user prefers reduced motion', () => {
+    mockReducedMotion(true);
+    const scrollSpy = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {});
+
+    scrollToTop();
+
+    expect(scrollSpy).toHaveBeenCalledWith({ top: 0, behavior: 'auto' });
+  });
+
+  it('falls back to smooth when matchMedia is unavailable', () => {
+    // @ts-expect-error simulate an environment without matchMedia
+    globalThis.matchMedia = undefined;
+    const scrollSpy = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {});
+
+    scrollToTop();
+
+    expect(scrollSpy).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+});

--- a/src/lib/scroll.ts
+++ b/src/lib/scroll.ts
@@ -1,0 +1,14 @@
+/**
+ * Smoothly scrolls the window back to the top.
+ *
+ * Used after navigation taps and after creating list items, so the user lands
+ * at a predictable position instead of being stranded mid-list. Honours
+ * `prefers-reduced-motion` by jumping instantly for users who opt out of motion.
+ */
+export function scrollToTop(): void {
+  const prefersReducedMotion =
+    globalThis.window !== undefined &&
+    !!globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+  globalThis.scrollTo({ top: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+}


### PR DESCRIPTION
## Why

Two transaction/category UX papercuts surfaced on mobile:

- After creating a transaction or category while scrolled deep into a list (via the mobile FAB), the user was left stranded mid-list — nowhere near their new entry. Cache invalidation refetches loaded pages *without* collapsing them, so the viewport never moved.
- The Add Transaction form auto-focused the amount field on open, popping the numeric keyboard and shoving the whole sheet upward before the user had oriented.

## What changed

- **Scroll to top after create.** Transactions scroll to the top on a successful *add* (default sort is newest-first, so the new row is revealed); editing does **not** scroll, since the edited row stays in place and moving the viewport would be disorienting. Categories already reset to page 0 on create — now they scroll up too, matching existing pagination behavior.
- **No auto-focus on the transaction form.** Dropped the `autoFocus` from the amount field and removed the now-dead `ref`/`useEffect` in `HeroAmountInput`. The form opens fully visible; the keyboard appears only when the user taps in.
- **Shared `scrollToTop()` helper** (`src/lib/scroll.ts`) replaces the duplicated `window.scrollTo({ top: 0, behavior: 'smooth' })` idiom across 4 call sites (transactions, categories ×2, `MobileNav`). It also honours `prefers-reduced-motion`, jumping instantly for users who opt out of motion.

## How to verify

1. `pnpm lint && pnpm test && pnpm build` — all green (303 tests).
2. On mobile/responsive: scroll deep into Transactions, tap the FAB, save a new transaction → list jumps to the top with the new entry visible.
3. Edit an existing transaction far down the list → viewport stays put (no scroll).
4. Open Add Transaction → amount is **not** focused and the keyboard does not auto-open; the sheet is fully visible.
5. Same create flow on Categories → list returns to top.

## Notes

- Sonar: new files analyzed clean (0 issues); aligned with the existing `globalThis` convention in `theme.store.ts`/`main.tsx`.
- If filters/sort exclude the new row, scroll-to-top still returns the user to a stable, predictable position rather than mid-list.