### PR TITLE
feat: optimize desktop layout with bento dashboard and nav rail

### DIFF
--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -89,7 +89,7 @@ export function DashboardPage() {
   const periodLabel = `${MONTH_NAMES_SHORT[selectedMonth]} ${selectedYear}`;
 
   return (
-    <PageContainer>
+    <PageContainer size="wide">
       <PageHeader
         title="Dashboard"
         isSubtitleEssential
@@ -191,20 +191,29 @@ export function DashboardPage() {
         </p>
       )}
 
-      <CategoriesCard
-        summary={summaryData}
-        isLoading={summaryLoading}
-        periodLabel={periodLabel}
-        firstDayOfPeriod={firstDayOfPeriod}
-        lastDayOfPeriod={lastDayOfPeriod}
-        currency={currency}
-      />
+      {/* On large screens the two insight cards sit side-by-side (3:2) instead
+          of stacking, filling the wider canvas. Collapses to the single-column
+          stack at md and below — mobile spacing is unchanged. */}
+      <div className="grid gap-6 lg:grid-cols-5 lg:items-start">
+        <div className="lg:col-span-3">
+          <CategoriesCard
+            summary={summaryData}
+            isLoading={summaryLoading}
+            periodLabel={periodLabel}
+            firstDayOfPeriod={firstDayOfPeriod}
+            lastDayOfPeriod={lastDayOfPeriod}
+            currency={currency}
+          />
+        </div>
 
-      <RecentTransactionsCard
-        transactions={recent}
-        isLoading={recentLoading}
-        hasFetched={!!recentData}
-      />
+        <div className="lg:col-span-2">
+          <RecentTransactionsCard
+            transactions={recent}
+            isLoading={recentLoading}
+            hasFetched={!!recentData}
+          />
+        </div>
+      </div>
     </PageContainer>
   );
 }

--- a/src/components/dashboard/DashboardSkeleton.tsx
+++ b/src/components/dashboard/DashboardSkeleton.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export function DashboardSkeleton() {
   return (
-    <PageContainer>
+    <PageContainer size="wide">
       <PageHeader
         title="Dashboard"
         isSubtitleEssential
@@ -20,8 +20,14 @@ export function DashboardSkeleton() {
         <SummaryCardSkeleton />
       </div>
 
-      <CategoriesCardSkeleton />
-      <RecentTransactionsCardSkeleton />
+      <div className="grid gap-6 lg:grid-cols-5 lg:items-start">
+        <div className="lg:col-span-3">
+          <CategoriesCardSkeleton />
+        </div>
+        <div className="lg:col-span-2">
+          <RecentTransactionsCardSkeleton />
+        </div>
+      </div>
     </PageContainer>
   );
 }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -3,7 +3,8 @@ import { ApiUnavailableBanner } from '@/components/ApiUnavailableBanner';
 import { OfflineBanner } from '@/components/OfflineBanner';
 import { FABProvider } from '@/contexts/fab-provider';
 import { Header } from './Header';
-import { MobileNav, SidebarNav } from './MobileNav';
+import { MobileNav } from './MobileNav';
+import { Sidebar } from './Sidebar';
 
 export function AppShell({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
@@ -20,20 +21,16 @@ export function AppShell({ children }: Readonly<{ children: React.ReactNode }>) 
         <Header />
         <div className="flex flex-1">
           {/* Sidebar — visible on md+ */}
-          <aside
-            aria-label="Sidebar navigation"
-            className="hidden w-56 shrink-0 border-r md:block sticky top-14 self-start h-[calc(100dvh-3.5rem)] overflow-y-auto"
-          >
-            <SidebarNav className="p-4" />
-          </aside>
+          <Sidebar />
 
-          {/* Main content — extra bottom padding on mobile to clear floating nav */}
+          {/* Main content — extra bottom padding on mobile to clear floating nav.
+              Width/centering is owned by PageContainer per page. */}
           <main
             id="main"
             aria-label="Main content"
-            className="flex-1 pb-[calc(env(safe-area-inset-bottom)+5rem)] md:pb-0"
+            className="min-w-0 flex-1 pb-[calc(env(safe-area-inset-bottom)+5rem)] md:pb-0"
           >
-            <div className="mx-auto max-w-2xl px-4 py-6 md:max-w-4xl md:px-6">{children}</div>
+            <div className="px-4 py-6 md:px-6 lg:py-8">{children}</div>
           </main>
         </div>
 

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -1,17 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { useAuth } from 'react-oidc-context';
 import { describe, expect, it, vi } from 'vitest';
 import { Header } from './Header';
-
-vi.mock('react-oidc-context', () => ({
-  useAuth: vi.fn(),
-}));
-
-vi.mock('@tanstack/react-query', () => ({
-  useQueryClient: vi.fn(() => ({
-    clear: vi.fn(),
-  })),
-}));
 
 let mockIsActive = false;
 
@@ -33,20 +22,12 @@ vi.stubGlobal('__APP_VERSION__', '1.0.0');
 
 describe('Header', () => {
   it('renders correctly', () => {
-    vi.mocked(useAuth).mockReturnValue({
-      signoutRedirect: vi.fn(),
-    } as unknown as ReturnType<typeof useAuth>);
-
     render(<Header />);
     expect(screen.getByText(/Budget Buddy/)).toBeInTheDocument();
     expect(screen.getByText(/v1.0.0/)).toBeInTheDocument();
   });
 
   it('shows active state for settings icon when isActive is true', () => {
-    vi.mocked(useAuth).mockReturnValue({
-      signoutRedirect: vi.fn(),
-    } as unknown as ReturnType<typeof useAuth>);
-
     mockIsActive = true;
     render(<Header />);
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,5 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import { LogOut, Settings } from 'lucide-react';
-import { useAuth } from 'react-oidc-context';
+import { Settings } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/cn';
 import { haptic } from '@/lib/haptics';
@@ -9,8 +7,6 @@ import { useThemeStore } from '@/stores/theme.store';
 
 export function Header() {
   const glassEffect = useThemeStore((s) => s.glassEffect);
-  const { signoutRedirect } = useAuth();
-  const queryClient = useQueryClient();
 
   return (
     <header
@@ -26,35 +22,22 @@ export function Header() {
         <span>Budget Buddy</span>
         <span className="ml-1.5 text-xs font-normal text-muted-foreground">v{__APP_VERSION__}</span>
       </Link>
-      <div className="flex items-center gap-1 sm:gap-2">
-        <Link to="/settings" className="inline-flex md:hidden">
-          {({ isActive }) => (
-            <Button
-              variant="ghost"
-              size="icon"
-              title="Settings"
-              aria-label="Settings"
-              className={cn('cursor-pointer', isActive && 'bg-primary/10 text-primary')}
-              onClick={() => haptic('tap')}
-            >
-              <Settings className="size-4" />
-            </Button>
-          )}
-        </Link>
-        <Button
-          variant="ghost"
-          size="icon"
-          title="Sign out"
-          aria-label="Sign out"
-          className="hidden cursor-pointer md:inline-flex"
-          onClick={() => {
-            queryClient.clear();
-            signoutRedirect();
-          }}
-        >
-          <LogOut className="size-4" />
-        </Button>
-      </div>
+      {/* Sign out lives in the desktop sidebar footer; on mobile the settings
+          link below is the only header action (nav is the floating bottom bar). */}
+      <Link to="/settings" className="inline-flex md:hidden">
+        {({ isActive }) => (
+          <Button
+            variant="ghost"
+            size="icon"
+            title="Settings"
+            aria-label="Settings"
+            className={cn('cursor-pointer', isActive && 'bg-primary/10 text-primary')}
+            onClick={() => haptic('tap')}
+          >
+            <Settings className="size-4" />
+          </Button>
+        )}
+      </Link>
     </header>
   );
 }

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -92,7 +92,9 @@ export function SidebarNav({ className }: Readonly<{ className?: string }>) {
           key={to}
           to={to}
           className="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground active:bg-accent/80 motion-reduce:transition-none focus-visible:focus-ring focus-visible:focus-ring-offset"
-          activeProps={{ className: 'bg-accent text-foreground font-medium' }}
+          activeProps={{
+            className: 'bg-primary/10 text-primary font-medium ring-1 ring-primary/20',
+          }}
           activeOptions={{ exact: to === '/', includeSearch: false }}
         >
           <Icon className="size-4" />

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { useAuth } from 'react-oidc-context';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar } from './Sidebar';
+
+const clear = vi.fn();
+
+vi.mock('react-oidc-context', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: vi.fn(() => ({ clear })),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
+}));
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue({
+      signoutRedirect: vi.fn(),
+    } as unknown as ReturnType<typeof useAuth>);
+  });
+
+  it('renders the primary navigation and the sign-out action', () => {
+    render(<Sidebar />);
+
+    expect(screen.getByRole('navigation', { name: 'Primary' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument();
+  });
+
+  it('clears cached queries before redirecting on sign out', () => {
+    const signoutRedirect = vi.fn();
+    vi.mocked(useAuth).mockReturnValue({
+      signoutRedirect,
+    } as unknown as ReturnType<typeof useAuth>);
+
+    render(<Sidebar />);
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+
+    expect(clear).toHaveBeenCalledTimes(1);
+    expect(signoutRedirect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,40 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { LogOut } from 'lucide-react';
+import { useAuth } from 'react-oidc-context';
+import { Button } from '@/components/ui/button';
+import { SidebarNav } from './MobileNav';
+
+/**
+ * Desktop navigation rail (md+). A sticky column with the primary nav at the
+ * top and account actions pinned to a footer at the bottom — the sign-out that
+ * used to be a stray icon in the header now lives here, next to the nav it
+ * belongs with. Hidden on mobile, where {@link MobileNav} takes over.
+ */
+export function Sidebar() {
+  const { signoutRedirect } = useAuth();
+  const queryClient = useQueryClient();
+
+  return (
+    <aside
+      aria-label="Sidebar navigation"
+      className="hidden w-56 shrink-0 flex-col border-r md:flex sticky top-14 self-start h-[calc(100dvh-3.5rem)] overflow-y-auto"
+    >
+      <SidebarNav className="flex-1 p-4" />
+      <div className="border-t p-3">
+        <Button
+          variant="ghost"
+          title="Sign out"
+          aria-label="Sign out"
+          className="w-full cursor-pointer justify-start gap-3 px-3 text-muted-foreground hover:text-foreground"
+          onClick={() => {
+            queryClient.clear();
+            signoutRedirect();
+          }}
+        >
+          <LogOut className="size-4" />
+          Sign out
+        </Button>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -13,7 +13,9 @@ export function SettingsPage() {
   return (
     <PageContainer>
       <PageHeader title="Settings" subtitle="Manage your application appearance and preferences." />
-      <div className="grid gap-6 md:max-w-2xl">
+      {/* Single column up to lg, then a balanced two-column grid that fills the
+          desktop canvas. Danger Zone spans the full width on its own row. */}
+      <div className="mx-auto grid max-w-2xl gap-6 lg:max-w-none lg:grid-cols-2 lg:items-start">
         <AccountSection />
         <PreferencesSection />
         <ThemeSection />
@@ -21,7 +23,9 @@ export function SettingsPage() {
         <FontSizeSection />
         <InterfaceSection />
         <VersionSection />
-        <DangerZoneSection />
+        <div className="lg:col-span-2">
+          <DangerZoneSection />
+        </div>
       </div>
     </PageContainer>
   );

--- a/src/components/settings/SettingsSkeleton.tsx
+++ b/src/components/settings/SettingsSkeleton.tsx
@@ -8,7 +8,7 @@ export function SettingsSkeleton() {
     <PageContainer>
       <PageHeader title="Settings" subtitle="Manage your application appearance and preferences." />
 
-      <div className="grid gap-6">
+      <div className="mx-auto grid max-w-2xl gap-6 lg:max-w-none lg:grid-cols-2 lg:items-start">
         {[1, 2, 3, 4, 5, 6].map((i) => (
           <section key={i} className="space-y-3">
             <div className="flex items-center gap-2">

--- a/src/components/ui/page-container.tsx
+++ b/src/components/ui/page-container.tsx
@@ -1,14 +1,34 @@
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/cn';
 
+/**
+ * Content width per page. `default` keeps the comfortable single-column
+ * reading width used everywhere today; `wide` lets the dashboard breathe into
+ * a multi-column bento on large screens. Mobile width is identical for both.
+ */
+type PageContainerSize = 'default' | 'wide';
+
 interface PageContainerProps {
   children: ReactNode;
   className?: string;
+  size?: PageContainerSize;
 }
 
+const SIZE_CLASSES: Record<PageContainerSize, string> = {
+  default: 'max-w-2xl md:max-w-4xl',
+  wide: 'max-w-2xl md:max-w-4xl lg:max-w-6xl',
+};
+
 /**
- * Standard container for all top-level pages to ensure consistent spacing.
+ * Standard container for all top-level pages — owns centering, max width and
+ * the consistent vertical rhythm between sections.
  */
-export function PageContainer({ children, className }: Readonly<PageContainerProps>) {
-  return <div className={cn('space-y-6', className)}>{children}</div>;
+export function PageContainer({
+  children,
+  className,
+  size = 'default',
+}: Readonly<PageContainerProps>) {
+  return (
+    <div className={cn('mx-auto w-full space-y-6', SIZE_CLASSES[size], className)}>{children}</div>
+  );
 }


### PR DESCRIPTION
## Why

Budget Buddy is mobile-first and polished on phones, but the desktop experience was a thin adaptation of the mobile layout: a single `max-w-4xl` column with everything stacked, a bare sidebar, and **Sign out** stranded as a lone icon in the header. On 1440px+ screens this left large dead space on both sides and stacked the dashboard's two insight cards instead of placing them side-by-side.

This PR reshapes **how desktop uses space**, following 2026 layout best practices.

## Scope & guarantees

- **Mobile is unchanged.** Every change is gated behind `md:`/`lg:` breakpoints; base (mobile) classes are preserved. The mobile content width now comes from `PageContainer` + the shell's outer padding, which is equivalent to the previous `mx-auto max-w-2xl px-4 py-6`.
- **Layout-focused only.** No changes to the visual language — colors, radii, shadows, spacing/typography tokens are untouched. We reshape *where* things sit, not *how they look*.

## Changes

| Area | Change |
|---|---|
| **Width system** | `PageContainer` now owns centering + width with a `size` prop (`default` \| `wide`); `AppShell` delegates per-page width to it instead of hard-coding `max-w-4xl`. |
| **Dashboard** | Becomes a 3:2 **bento** on `lg` — "Expenses by category" (`col-span-3`) and "Recent transactions" (`col-span-2`) sit side-by-side instead of stacking. Wider canvas (`lg:max-w-6xl`). Collapses to the existing single-column stack at `md` and below. |
| **Settings** | Sections lay out in **two columns** on `lg` (Danger Zone spans full width). Single column below `lg`, as today. |
| **Sidebar** | New `Sidebar` nav rail: primary-tint active states (matching the mobile nav) and a **pinned footer holding Sign out**, moved out of the header. |
| **Header** | Desktop sign-out removed (now in the sidebar); logo, version, and the mobile-only Settings link are untouched. |
| **Skeletons** | Dashboard + Settings skeletons mirror the new grids to avoid a load-time width/shape shift. |

## Decisions

- **Transactions & Categories lists left as-is** — single-column scannable lists read best at a comfortable width; widening them would hurt, not help.

## Tests

- New `Sidebar.test.tsx` covers the relocated sign-out (renders the control; clicking clears the query cache then redirects).
- `Header.test.tsx` simplified to drop now-dead `useAuth`/`useQueryClient` mocks.

## Verification

- `pnpm lint` — ESLint + Biome clean
- `pnpm test` — 305 passed (incl. a11y, which render page components directly and are unaffected)
- `pnpm build` — production build + `tsc -b` pass
- Sonar quality gate checked on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)