### PR TITLE
fix: revert bento desktop layout, make sign-out match nav items

### DIFF
--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -89,7 +89,7 @@ export function DashboardPage() {
   const periodLabel = `${MONTH_NAMES_SHORT[selectedMonth]} ${selectedYear}`;
 
   return (
-    <PageContainer size="wide">
+    <PageContainer>
       <PageHeader
         title="Dashboard"
         isSubtitleEssential
@@ -191,29 +191,20 @@ export function DashboardPage() {
         </p>
       )}
 
-      {/* On large screens the two insight cards sit side-by-side (3:2) instead
-          of stacking, filling the wider canvas. Collapses to the single-column
-          stack at md and below — mobile spacing is unchanged. */}
-      <div className="grid gap-6 lg:grid-cols-5 lg:items-start">
-        <div className="lg:col-span-3">
-          <CategoriesCard
-            summary={summaryData}
-            isLoading={summaryLoading}
-            periodLabel={periodLabel}
-            firstDayOfPeriod={firstDayOfPeriod}
-            lastDayOfPeriod={lastDayOfPeriod}
-            currency={currency}
-          />
-        </div>
+      <CategoriesCard
+        summary={summaryData}
+        isLoading={summaryLoading}
+        periodLabel={periodLabel}
+        firstDayOfPeriod={firstDayOfPeriod}
+        lastDayOfPeriod={lastDayOfPeriod}
+        currency={currency}
+      />
 
-        <div className="lg:col-span-2">
-          <RecentTransactionsCard
-            transactions={recent}
-            isLoading={recentLoading}
-            hasFetched={!!recentData}
-          />
-        </div>
-      </div>
+      <RecentTransactionsCard
+        transactions={recent}
+        isLoading={recentLoading}
+        hasFetched={!!recentData}
+      />
     </PageContainer>
   );
 }

--- a/src/components/dashboard/DashboardSkeleton.tsx
+++ b/src/components/dashboard/DashboardSkeleton.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export function DashboardSkeleton() {
   return (
-    <PageContainer size="wide">
+    <PageContainer>
       <PageHeader
         title="Dashboard"
         isSubtitleEssential
@@ -20,14 +20,8 @@ export function DashboardSkeleton() {
         <SummaryCardSkeleton />
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-5 lg:items-start">
-        <div className="lg:col-span-3">
-          <CategoriesCardSkeleton />
-        </div>
-        <div className="lg:col-span-2">
-          <RecentTransactionsCardSkeleton />
-        </div>
-      </div>
+      <CategoriesCardSkeleton />
+      <RecentTransactionsCardSkeleton />
     </PageContainer>
   );
 }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -23,14 +23,13 @@ export function AppShell({ children }: Readonly<{ children: React.ReactNode }>) 
           {/* Sidebar — visible on md+ */}
           <Sidebar />
 
-          {/* Main content — extra bottom padding on mobile to clear floating nav.
-              Width/centering is owned by PageContainer per page. */}
+          {/* Main content — extra bottom padding on mobile to clear floating nav */}
           <main
             id="main"
             aria-label="Main content"
             className="min-w-0 flex-1 pb-[calc(env(safe-area-inset-bottom)+5rem)] md:pb-0"
           >
-            <div className="px-4 py-6 md:px-6 lg:py-8">{children}</div>
+            <div className="mx-auto max-w-2xl px-4 py-6 md:max-w-4xl md:px-6">{children}</div>
           </main>
         </div>
 

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -92,9 +92,7 @@ export function SidebarNav({ className }: Readonly<{ className?: string }>) {
           key={to}
           to={to}
           className="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground active:bg-accent/80 motion-reduce:transition-none focus-visible:focus-ring focus-visible:focus-ring-offset"
-          activeProps={{
-            className: 'bg-primary/10 text-primary font-medium ring-1 ring-primary/20',
-          }}
+          activeProps={{ className: 'bg-accent text-foreground font-medium' }}
           activeOptions={{ exact: to === '/', includeSearch: false }}
         >
           <Icon className="size-4" />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,15 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { LogOut } from 'lucide-react';
 import { useAuth } from 'react-oidc-context';
-import { Button } from '@/components/ui/button';
 import { SidebarNav } from './MobileNav';
 
-/**
- * Desktop navigation rail (md+). A sticky column with the primary nav at the
- * top and account actions pinned to a footer at the bottom — the sign-out that
- * used to be a stray icon in the header now lives here, next to the nav it
- * belongs with. Hidden on mobile, where {@link MobileNav} takes over.
- */
 export function Sidebar() {
   const { signoutRedirect } = useAuth();
   const queryClient = useQueryClient();
@@ -21,11 +14,11 @@ export function Sidebar() {
     >
       <SidebarNav className="flex-1 p-4" />
       <div className="border-t p-3">
-        <Button
-          variant="ghost"
+        <button
+          type="button"
           title="Sign out"
           aria-label="Sign out"
-          className="w-full cursor-pointer justify-start gap-3 px-3 text-muted-foreground hover:text-foreground"
+          className="flex w-full cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground active:bg-accent/80 motion-reduce:transition-none focus-visible:focus-ring focus-visible:focus-ring-offset"
           onClick={() => {
             queryClient.clear();
             signoutRedirect();
@@ -33,7 +26,7 @@ export function Sidebar() {
         >
           <LogOut className="size-4" />
           Sign out
-        </Button>
+        </button>
       </div>
     </aside>
   );

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -13,9 +13,7 @@ export function SettingsPage() {
   return (
     <PageContainer>
       <PageHeader title="Settings" subtitle="Manage your application appearance and preferences." />
-      {/* Single column up to lg, then a balanced two-column grid that fills the
-          desktop canvas. Danger Zone spans the full width on its own row. */}
-      <div className="mx-auto grid max-w-2xl gap-6 lg:max-w-none lg:grid-cols-2 lg:items-start">
+      <div className="grid gap-6 md:max-w-2xl">
         <AccountSection />
         <PreferencesSection />
         <ThemeSection />
@@ -23,9 +21,7 @@ export function SettingsPage() {
         <FontSizeSection />
         <InterfaceSection />
         <VersionSection />
-        <div className="lg:col-span-2">
-          <DangerZoneSection />
-        </div>
+        <DangerZoneSection />
       </div>
     </PageContainer>
   );

--- a/src/components/settings/SettingsSkeleton.tsx
+++ b/src/components/settings/SettingsSkeleton.tsx
@@ -8,7 +8,7 @@ export function SettingsSkeleton() {
     <PageContainer>
       <PageHeader title="Settings" subtitle="Manage your application appearance and preferences." />
 
-      <div className="mx-auto grid max-w-2xl gap-6 lg:max-w-none lg:grid-cols-2 lg:items-start">
+      <div className="grid gap-6">
         {[1, 2, 3, 4, 5, 6].map((i) => (
           <section key={i} className="space-y-3">
             <div className="flex items-center gap-2">

--- a/src/components/ui/page-container.tsx
+++ b/src/components/ui/page-container.tsx
@@ -1,34 +1,11 @@
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/cn';
 
-/**
- * Content width per page. `default` keeps the comfortable single-column
- * reading width used everywhere today; `wide` lets the dashboard breathe into
- * a multi-column bento on large screens. Mobile width is identical for both.
- */
-type PageContainerSize = 'default' | 'wide';
-
 interface PageContainerProps {
   children: ReactNode;
   className?: string;
-  size?: PageContainerSize;
 }
 
-const SIZE_CLASSES: Record<PageContainerSize, string> = {
-  default: 'max-w-2xl md:max-w-4xl',
-  wide: 'max-w-2xl md:max-w-4xl lg:max-w-6xl',
-};
-
-/**
- * Standard container for all top-level pages — owns centering, max width and
- * the consistent vertical rhythm between sections.
- */
-export function PageContainer({
-  children,
-  className,
-  size = 'default',
-}: Readonly<PageContainerProps>) {
-  return (
-    <div className={cn('mx-auto w-full space-y-6', SIZE_CLASSES[size], className)}>{children}</div>
-  );
+export function PageContainer({ children, className }: Readonly<PageContainerProps>) {
+  return <div className={cn('space-y-6', className)}>{children}</div>;
 }


### PR DESCRIPTION
## Why

The lg bento grid on the dashboard and two-column settings layout from #176 added visual complexity without a clear payoff. Rolling back to the comfortable single-column layout. The one improvement worth keeping from #176 — sign-out living in the sidebar footer instead of a lone header icon — is preserved, but restyled so it looks like a natural part of the nav.

## What changed

- **Dashboard + skeleton** — removed `size="wide"` and the `lg:grid-cols-5` bento; `CategoriesCard` and `RecentTransactionsCard` stack vertically again
- **Settings + skeleton** — removed `lg:grid-cols-2`; sections are back to a single capped-width column (`md:max-w-2xl`)
- **AppShell** — restored the `mx-auto max-w-2xl … md:max-w-4xl` centering wrapper inside `<main>`; `PageContainer` goes back to being just `space-y-6`
- **page-container** — removed the `wide` size variant (nothing uses it after the above)
- **Sidebar sign-out** — replaced `Button variant="ghost"` with a plain `<button>` carrying the exact same Tailwind classes as `SidebarNav` Link items (`rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground active:bg-accent/80`)
- **MobileNav SidebarNav** — reverted `activeProps` back to `bg-accent text-foreground font-medium`

Mobile is entirely unchanged.

## How to verify

1. `pnpm dev` — open the app on a desktop viewport (≥768 px)
2. Dashboard: cards stack vertically; no side-by-side bento at any breakpoint
3. Settings: sections form a single column capped at ~672 px
4. Sidebar: "Sign out" looks identical in size, padding, and hover style to the nav links above it
5. Resize to mobile — layout and sign-out icon in header are unchanged
6. `pnpm lint && pnpm build` — both pass clean